### PR TITLE
Fix panic on handle_click

### DIFF
--- a/src/graph_view.rs
+++ b/src/graph_view.rs
@@ -141,8 +141,10 @@ impl<'a> GraphView<'a> {
 
         // click on empty space
         let node = self.node_by_pos(metadata, response.hover_pos().unwrap());
-        if node.is_none() && self.setings_interaction.node_select {
-            self.deselect_all_nodes(state);
+        if node.is_none() {
+            if self.setings_interaction.node_select {
+                self.deselect_all_nodes(state);
+            }
             return;
         }
 


### PR DESCRIPTION
When node_click is enabled but node_select is not, the code assumed that the node exists.
```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', egui_graphs/src/graph_view.rs:149:29
```