### PR TITLE
[Feature] Ability to implement custom drawing functions

### DIFF
--- a/src/graph_view.rs
+++ b/src/graph_view.rs
@@ -1,7 +1,7 @@
 use crate::{
     change::ChangeNode,
     change::{Change, ChangeSubgraph},
-    drawer::Drawer,
+    drawer::{CustomNodeDrawingFn, CustomNodeInteractedDrawingFn, Drawer},
     elements::Node,
     graph_wrapper::GraphWrapper,
     metadata::Metadata,
@@ -41,6 +41,8 @@ pub struct GraphView<'a, N: Clone, E: Clone, Ty: EdgeType> {
     settings_style: SettingsStyle,
     g: GraphWrapper<'a, N, E, Ty>,
     changes_sender: Option<&'a Sender<Change>>,
+    custom_node_drawing_fn: CustomNodeDrawingFn<N>,
+    custom_node_interacted_drawing_fn: CustomNodeInteractedDrawingFn<N>,
 }
 
 impl<'a, N: Clone, E: Clone, Ty: EdgeType> Widget for &mut GraphView<'a, N, E, Ty> {
@@ -56,7 +58,15 @@ impl<'a, N: Clone, E: Clone, Ty: EdgeType> Widget for &mut GraphView<'a, N, E, T
         self.handle_node_drag(&resp, &mut computed, &mut meta);
         self.handle_click(&resp, &mut computed, &mut meta);
 
-        Drawer::new(&self.g, &p, &computed, &self.settings_style).draw();
+        Drawer::new(
+            &self.g,
+            &p,
+            &computed,
+            &self.settings_style,
+            self.custom_node_drawing_fn,
+            self.custom_node_interacted_drawing_fn,
+        )
+        .draw();
 
         self.send_comp_changes(&computed);
 
@@ -78,6 +88,9 @@ impl<'a, N: Clone, E: Clone, Ty: EdgeType> GraphView<'a, N, E, Ty> {
             settings_interaction: Default::default(),
             settings_navigation: Default::default(),
             changes_sender: Default::default(),
+
+            custom_node_drawing_fn: None,
+            custom_node_interacted_drawing_fn: None,
         }
     }
 
@@ -104,6 +117,24 @@ impl<'a, N: Clone, E: Clone, Ty: EdgeType> GraphView<'a, N, E, Ty> {
     /// Modifies default style settings.
     pub fn with_styles(mut self, settings_style: &SettingsStyle) -> Self {
         self.settings_style = settings_style.clone();
+        self
+    }
+
+    /// Ability to implement custom node drawing
+    pub fn with_custom_node_drawing(
+        mut self,
+        custom_node_drawing_fn: CustomNodeDrawingFn<N>,
+    ) -> Self {
+        self.custom_node_drawing_fn = custom_node_drawing_fn;
+        self
+    }
+
+    /// Ability to implement custom node drawing when interacted
+    pub fn with_custom_node_interacted_drawing(
+        mut self,
+        custom_node_interacted_drawing_fn: CustomNodeInteractedDrawingFn<N>,
+    ) -> Self {
+        self.custom_node_interacted_drawing_fn = custom_node_interacted_drawing_fn;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,11 @@ mod subgraphs;
 mod transform;
 
 pub use self::change::{Change, ChangeEdge, ChangeNode, ChangeSubgraph};
+pub use self::drawer::{ShapesEdges, ShapesNodes};
 pub use self::elements::{Edge, Node};
 pub use self::graph_view::{Graph, GraphView};
 pub use self::settings::{SettingsInteraction, SettingsNavigation, SettingsStyle};
+pub use self::state_computed::StateComputedNode;
 pub use self::subgraphs::SubGraph;
 pub use self::transform::{
     add_edge, add_node, add_node_custom, default_edge_transform, default_node_transform,


### PR DESCRIPTION
Hi, I've added a way of implementing custom node drawing functions.

Here's an example usage:
```
use eframe::{run_native, App, CreationContext};
use egui::{
    epaint::{CircleShape, RectShape},
    Color32, Context, Pos2, Rect, Rounding, Stroke,
};
use egui_graphs::{
    to_input_graph, Graph, GraphView, Node, SettingsInteraction, ShapesNodes, StateComputedNode,
};
use petgraph::{stable_graph::StableGraph, Directed};

pub struct BasicApp {
    g: Graph<(), (), Directed>,
}

impl BasicApp {
    fn new(_: &CreationContext<'_>) -> Self {
        let g = generate_graph();
        Self { g }
    }
}

impl App for BasicApp {
    fn update(&mut self, ctx: &Context, _: &mut eframe::Frame) {
        let a = SettingsInteraction::new().with_dragging_enabled(true);
        egui::CentralPanel::default().show(ctx, |ui| {
            ui.add(
                &mut GraphView::new(&mut self.g)
                    .with_interactions(&a)
                    .with_custom_node_drawing(Some(
                        |res: &mut (ShapesNodes, ShapesNodes),
                         loc: Pos2,
                         node: &Node<()>,
                         comp_node: &StateComputedNode| {
                            let color = Color32::from_rgb(0, 0, 0);
                            let shape = CircleShape {
                                center: loc,
                                radius: 20.0,
                                fill: color,
                                stroke: Stroke::new(1., color),
                            };
                            res.0 .0.push(shape.into());
                        },
                    ))
                    .with_custom_node_interacted_drawing(Some(
                        |res: &mut (ShapesNodes, ShapesNodes),
                         loc: Pos2,
                         node: &Node<()>,
                         comp_node: &StateComputedNode| {
                            if !(node.selected()
                                || comp_node.subselected()
                                || node.dragged()
                                || node.folded()
                                || comp_node.subfolded())
                            {
                                return;
                            }

                            let color = Color32::from_rgb(50, 0, 0);
                            let rounding = Rounding::default();

                            let mut min_rec = loc;
                            min_rec.x -= 20.0;
                            min_rec.y -= 20.0;

                            let mut max_rec = loc;
                            max_rec.x += 20.0;
                            max_rec.y += 20.0;

                            let rect = Rect {
                                min: min_rec,
                                max: max_rec,
                            };

                            let shape = RectShape {
                                rect,
                                rounding,
                                fill: color,
                                stroke: Stroke::new(1., color),
                            };
                            res.1 .0.push(shape.into());
                        },
                    )),
            );
        });
    }
}

fn generate_graph() -> Graph<(), (), Directed> {
    let mut g: StableGraph<(), ()> = StableGraph::new();

    let a = g.add_node(());
    let b = g.add_node(());
    let c = g.add_node(());

    g.add_edge(a, b, ());
    g.add_edge(b, c, ());
    g.add_edge(c, a, ());

    to_input_graph(&g)
}

fn main() {
    let native_options = eframe::NativeOptions::default();
    run_native(
        "egui_graphs_basic_demo",
        native_options,
        Box::new(|cc| Box::new(BasicApp::new(cc))),
    )
    .unwrap();
}
```