### PR TITLE
[Feature] Ability to set/change data after node creation

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -169,6 +169,12 @@ impl<E: Clone> Edge<E> {
         self.width
     }
 
+    pub fn with_width(&mut self, width: f32) -> Self {
+        let mut res = self.clone();
+        res.width = width;
+        res
+    }
+
     pub fn curve_size(&self) -> f32 {
         self.curve_size
     }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -46,6 +46,16 @@ impl<N: Clone> Node<N> {
         self.data.as_ref()
     }
 
+    pub fn set_data(&mut self, data: Option<N>) {
+        self.data = data;
+    }
+
+    pub fn with_data(&self, data: Option<N>) -> Self {
+        let mut res = self.clone();
+        res.data = data;
+        res
+    }
+
     pub fn location(&self) -> Vec2 {
         self.location
     }


### PR DESCRIPTION
I've hit this roadblock sooo many times. I try to update the underlying data, but I am unable to, because the library only returns read-only ref to current data. At the moment, only option to overcome this problem is to re-generate the node. This commit fixes that by adding methods (mutable and immutable) for changing the underlying data.