### PR TITLE
Specifically specify required features for dependent crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ description = "Interactive graph visualization widget for rust powered by egui"
 edition = "2021"
 
 [dependencies]
-egui = "0.23"
+egui = { version = "0.23", default-features = false }
 rand = "0.8"
-petgraph = "0.6"
+petgraph = { version = "0.6", default-features = false, features = ["stable_graph", "matrix_graph"] }
 crossbeam = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
Hi!

This PR intends to clean up some external crate features that aren't required for `egui_graphs` to work. Specifically, this removes `egui/default_fonts` and `petgraph/graphmap`. I've checked the other dependencies as well but it appears they don't further enable features that aren't required.

Not including `egui/default_fonts` (which enables `epaint/default_fonts`) might be particularly interesting because it pulls in font files that have additional licenses. This is what initially triggered me to make this change 🙂.