### PR TITLE
Remove stroke from node circle shape

### DIFF
--- a/src/draw/node.rs
+++ b/src/draw/node.rs
@@ -27,7 +27,7 @@ pub fn default_node_draw<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType>(
         center: loc,
         radius: rad,
         fill: color,
-        stroke: Stroke::new(1., color),
+        stroke: Stroke::NONE,
     };
     match is_interacted {
         true => l.add_top(shape_node),


### PR DESCRIPTION
It seems the node draws with a circle shape that uses a stroke style with the same color as the fill color of the circle itself. In other words, the stroke isn't very visible as such, but it adds quite some complexity to the rendering, as the strokes around the circle are fully tesselated triangles, as you can see in this capture I made with PIX.

![image](https://github.com/blitzarx1/egui_graphs/assets/21238776/408703db-6885-4eec-a33d-d35fe18fdbb7)
<sup>(Don't mind the two rings, that's not a bug in drawing, that's just because my app put a couple of nodes on top of each other, where one is selected and the other isn't)</sup>

Removing the stroke saved quite some time rendering a graph of mine, despite there being no visual difference 🙂 (well, I guess all circles have become half a unit smaller). This particular graph went from 20ms to 1ms.

![image](https://github.com/blitzarx1/egui_graphs/assets/21238776/e81c72c7-7484-4abc-bf42-e686bf6d9b9d)
