### PR TITLE
Correct drawing and zoom when containing rect is not at (0, 0)

### DIFF
--- a/src/graph_view.rs
+++ b/src/graph_view.rs
@@ -74,6 +74,7 @@ impl<'a, N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> Widget
         )
         .draw();
 
+        meta.first_frame = false;
         meta.store_into_ui(ui);
         ui.ctx().request_repaint();
 
@@ -171,7 +172,6 @@ impl<'a, N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> GraphView<'a, N, E, Ty
         }
 
         self.fit_to_screen(&r.rect, meta, comp);
-        meta.first_frame = false;
     }
 
     fn handle_click(&mut self, resp: &Response, meta: &mut Metadata, comp: &ComputedState<Ix>) {
@@ -384,6 +384,11 @@ impl<'a, N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> GraphView<'a, N, E, Ty
         meta: &mut Metadata,
         comp: &ComputedState<Ix>,
     ) {
+        if !meta.first_frame {
+            meta.pan += resp.rect.left_top() - meta.left_top;
+        }
+        meta.left_top = resp.rect.left_top();
+
         self.handle_zoom(ui, resp, meta);
         self.handle_pan(resp, meta, comp);
     }
@@ -420,10 +425,7 @@ impl<'a, N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> GraphView<'a, N, E, Ty
 
     /// Zooms the graph by the given delta. It also compensates with pan to keep the zoom center in the same place.
     fn zoom(&self, rect: &Rect, delta: f32, zoom_center: Option<Pos2>, meta: &mut Metadata) {
-        let center_pos = match zoom_center {
-            Some(center_pos) => center_pos - rect.min,
-            None => rect.center() - rect.min,
-        };
+        let center_pos = zoom_center.unwrap_or(rect.center()).to_vec2();
         let graph_center_pos = (center_pos - meta.pan) / meta.zoom;
         let factor = 1. + delta;
         let new_zoom = meta.zoom * factor;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,4 +1,4 @@
-use egui::{Id, Vec2};
+use egui::{Id, Pos2, Vec2};
 
 #[cfg(feature = "egui_persistence")]
 use serde::{Deserialize, Serialize};
@@ -12,6 +12,8 @@ pub struct Metadata {
     pub zoom: f32,
     /// Current pan offset
     pub pan: Vec2,
+    /// Top left position of widget
+    pub left_top: Pos2,
 }
 
 impl Default for Metadata {
@@ -20,6 +22,7 @@ impl Default for Metadata {
             first_frame: true,
             zoom: 1.,
             pan: Default::default(),
+            left_top: Default::default(),
         }
     }
 }


### PR DESCRIPTION
In my app I put a graph in a `Window` widget which can be freely moved around. It appears that because nodes are always drawing at certain screen positions, the actual graph just stays fixed relative to the app frame, and the window widget sort of becomes a window into the graph.

Also, the zoom center is wrongly calculated because that is in fact using relative coordinates to the parent rect, while the graph is always in screen space.

This PR fixes both issues. When the parent widget is moved on screen, the pan is adjusted so the graph moves with the window. Note that this adjustment does not generate a panning event. I wasn't quite sure whether that is desirable. I'll happily add it if you think that is best.

Another approach I considered was not adjusting the pan, but instead always draw everything relative to the containing rect. The reason I did not opt for this approach was that it would likely break existing custom draws. However, I do recon this is a generally better approach, but perhaps that should be incorporated together with #108 when things are going to break either way 🙂