### PR TITLE
Default indices & pan, zoom payload contains new values

### DIFF
--- a/src/elements/edge.rs
+++ b/src/elements/edge.rs
@@ -26,7 +26,7 @@ impl<Ix: IndexType> EdgeID<Ix> {
 
 /// Stores properties of an edge that can be changed. Used to apply changes to the graph.
 #[derive(Clone, Debug)]
-pub struct Edge<E: Clone, Ix: IndexType> {
+pub struct Edge<E: Clone, Ix: IndexType=DefaultIx> {
     id: Option<EdgeID<Ix>>,
 
     /// Client data

--- a/src/elements/edge.rs
+++ b/src/elements/edge.rs
@@ -1,9 +1,9 @@
 use egui::{Color32, Context};
-use petgraph::stable_graph::{EdgeIndex, IndexType};
+use petgraph::stable_graph::{EdgeIndex, IndexType, DefaultIx};
 
 /// Uniquely identifies edge with source, target and index in the set of duplicate edges.
 #[derive(Clone, Debug)]
-pub struct EdgeID<Ix: IndexType> {
+pub struct EdgeID<Ix: IndexType=DefaultIx> {
     pub idx: EdgeIndex<Ix>,
 
     /// Index of the edge among siblings.

--- a/src/elements/node.rs
+++ b/src/elements/node.rs
@@ -1,11 +1,11 @@
 use egui::Pos2;
-use petgraph::stable_graph::{IndexType, NodeIndex};
+use petgraph::stable_graph::{IndexType, NodeIndex, DefaultIx};
 
 use crate::ComputedNode;
 
 /// Stores properties of a node.
 #[derive(Clone, Debug)]
-pub struct Node<N: Clone, Ix: IndexType> {
+pub struct Node<N: Clone, Ix: IndexType=DefaultIx> {
     id: Option<NodeIndex<Ix>>,
     location: Option<Pos2>,
 

--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -3,11 +3,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PayloadPan {
     pub diff: [f32; 2],
+    pub new_pan: [f32; 2]
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PayloadZoom {
     pub diff: f32,
+    pub new_zoom: f32
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/graph_view.rs
+++ b/src/graph_view.rs
@@ -547,21 +547,21 @@ where
     }
 
     #[allow(unused_variables)]
-    fn set_pan(&self, val: Vec2, meta: &mut Metadata) {
-        let diff = val - meta.pan;
-        meta.pan = val;
+    fn set_pan(&self, new_pan: Vec2, meta: &mut Metadata) {
+        let diff = new_pan - meta.pan;
+        meta.pan = new_pan;
 
         #[cfg(feature = "events")]
-        self.publish_event(Event::Pan(PayloadPan { diff: diff.into() }));
+        self.publish_event(Event::Pan(PayloadPan { diff: diff.into(), new_pan: new_pan.into() }));
     }
 
     #[allow(unused_variables)]
-    fn set_zoom(&self, val: f32, meta: &mut Metadata) {
-        let diff = val - meta.zoom;
-        meta.zoom = val;
+    fn set_zoom(&self, new_zoom: f32, meta: &mut Metadata) {
+        let diff = new_zoom - meta.zoom;
+        meta.zoom = new_zoom;
 
         #[cfg(feature = "events")]
-        self.publish_event(Event::Zoom(PayloadZoom { diff }));
+        self.publish_event(Event::Zoom(PayloadZoom { diff, new_zoom }));
     }
 
     #[cfg(feature = "events")]


### PR DESCRIPTION
So that the user doesn't have to specify the index always.