### PR TITLE
moving display inside of node

### DIFF
--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -23,7 +23,7 @@ impl App for BasicApp {
                 _,
                 _,
                 DefaultNodeShape,
-                DefaultEdgeShape<_>,
+                DefaultEdgeShape,
             >::new(&mut self.g));
         });
     }

--- a/examples/bevy_basic/src/main.rs
+++ b/examples/bevy_basic/src/main.rs
@@ -52,7 +52,7 @@ fn update_graph(mut contexts: EguiContexts, mut q_graph: Query<&mut BasicGraph>)
             _,
             _,
             DefaultNodeShape,
-            DefaultEdgeShape<_>,
+            DefaultEdgeShape,
         >::new(&mut graph.0));
     });
 }

--- a/examples/bevy_basic_multiple/src/main.rs
+++ b/examples/bevy_basic_multiple/src/main.rs
@@ -53,7 +53,7 @@ fn ui_example_system(mut contexts: EguiContexts, mut graph_provider: ResMut<Grap
         .show(ctx, |ui| {
             ui.child_ui(ui.max_rect(), Layout::default());
             ui.add(
-                &mut GraphView::<_, _, _, _, DefaultNodeShape, DefaultEdgeShape<_>>::new(
+                &mut GraphView::<_, _, _, _, DefaultNodeShape, DefaultEdgeShape>::new(
                     &mut graph_provider.g,
                 )
                 .with_navigations(&SettingsNavigation::default().with_fit_to_screen_enabled(false)),
@@ -64,7 +64,7 @@ fn ui_example_system(mut contexts: EguiContexts, mut graph_provider: ResMut<Grap
         .resizable(true)
         .show(ctx, |ui| {
             ui.add(
-                &mut GraphView::<_, _, _, _, DefaultNodeShape, DefaultEdgeShape<_>>::new(
+                &mut GraphView::<_, _, _, _, DefaultNodeShape, DefaultEdgeShape>::new(
                     &mut graph_provider.g,
                 )
                 .with_navigations(&SettingsNavigation::default().with_fit_to_screen_enabled(false)),
@@ -72,7 +72,7 @@ fn ui_example_system(mut contexts: EguiContexts, mut graph_provider: ResMut<Grap
         });
     egui::CentralPanel::default().show(ctx, |ui| {
         ui.add(
-            &mut GraphView::<_, _, _, _, DefaultNodeShape, DefaultEdgeShape<_>>::new(
+            &mut GraphView::<_, _, _, _, DefaultNodeShape, DefaultEdgeShape>::new(
                 &mut graph_provider.g,
             )
             .with_navigations(&SettingsNavigation::default().with_fit_to_screen_enabled(false)),

--- a/examples/configurable/src/main.rs
+++ b/examples/configurable/src/main.rs
@@ -58,13 +58,13 @@ impl ConfigurableApp {
 
             settings_graph,
 
-            settings_interaction: Default::default(),
-            settings_navigation: Default::default(),
-            settings_style: Default::default(),
+            settings_interaction: SettingsInteraction::default(),
+            settings_navigation: SettingsNavigation::default(),
+            settings_style: SettingsStyle::default(),
 
-            selected_nodes: Default::default(),
-            selected_edges: Default::default(),
-            last_events: Default::default(),
+            selected_nodes: Vec::default(),
+            selected_edges: Vec::default(),
+            last_events: Vec::default(),
 
             simulation_stopped: false,
 
@@ -72,8 +72,8 @@ impl ConfigurableApp {
             last_update_time: Instant::now(),
             frames_last_time_span: 0,
 
-            pan: Default::default(),
-            zoom: Default::default(),
+            pan: Option::default(),
+            zoom: Option::default(),
         }
     }
 
@@ -130,7 +130,7 @@ impl ConfigurableApp {
         self.selected_nodes = vec![];
 
         let g_indices = self.g.g.node_indices().collect::<Vec<_>>();
-        g_indices.iter().for_each(|g_n_idx| {
+        for g_n_idx in &g_indices {
             let g_n = self.g.g.node_weight_mut(*g_n_idx).unwrap();
             let sim_n = self.sim.get_graph_mut().node_weight_mut(*g_n_idx).unwrap();
 
@@ -140,7 +140,7 @@ impl ConfigurableApp {
             if g_n.selected() {
                 self.selected_nodes.push(g_n.clone());
             }
-        });
+        }
 
         // reset the weights of the edges
         self.sim.get_graph_mut().edge_weights_mut().for_each(|w| {
@@ -166,7 +166,7 @@ impl ConfigurableApp {
         self.g = g;
         self.sim = sim;
         self.settings_graph = settings_graph;
-        self.last_events = Default::default();
+        self.last_events = Vec::default();
 
         GraphView::<(), (), Directed, DefaultIx>::reset_metadata(ui);
     }
@@ -253,7 +253,7 @@ impl ConfigurableApp {
         self.g.g[idx].bind(idx, location);
 
         let n = self.g.g.node_weight_mut(idx).unwrap();
-        n.set_label(format!("{:?}", idx));
+        n.set_label(format!("{idx:?}"));
 
         let mut sim_node = fdg_sim::Node::new(idx.index().to_string().as_str(), ());
         sim_node.location = Vec3::new(location.x, location.y, 0.);
@@ -263,10 +263,10 @@ impl ConfigurableApp {
     fn remove_node(&mut self, idx: NodeIndex) {
         // before removing nodes we need to remove all edges connected to it
         let neighbors = self.g.g.neighbors_undirected(idx).collect::<Vec<_>>();
-        neighbors.iter().for_each(|n| {
+        for n in &neighbors {
             self.remove_edges(idx, *n);
             self.remove_edges(*n, idx);
-        });
+        }
 
         self.g.g.remove_node(idx).unwrap();
         self.sim.get_graph_mut().remove_node(idx).unwrap();
@@ -323,7 +323,7 @@ impl ConfigurableApp {
             .map(|edge_ref| edge_ref.id())
             .collect::<Vec<_>>();
 
-        left_siblings.iter().for_each(|idx| {
+        for idx in &left_siblings {
             let sibling_order = self.g.g.edge_weight(*idx).unwrap().order();
             if sibling_order < order {
                 return;
@@ -333,7 +333,7 @@ impl ConfigurableApp {
                 .edge_weight_mut(*idx)
                 .unwrap()
                 .set_order(sibling_order - 1);
-        });
+        }
     }
 
     /// Removes all edges between two nodes
@@ -617,7 +617,7 @@ fn construct_simulation(g: &Graph<(), (), Directed, DefaultIx>) -> Simulation<()
     let mut force_graph = ForceGraph::with_capacity(g.g.node_count(), g.g.edge_count());
     g.g.node_indices().for_each(|idx| {
         let idx = idx.index();
-        force_graph.add_force_node(format!("{}", idx).as_str(), ());
+        force_graph.add_force_node(format!("{idx}").as_str(), ());
     });
     g.g.edge_indices().for_each(|idx| {
         let (source, target) = g.g.edge_endpoints(idx).unwrap();

--- a/examples/configurable/src/main.rs
+++ b/examples/configurable/src/main.rs
@@ -27,7 +27,7 @@ pub struct ConfigurableApp {
     settings_navigation: SettingsNavigation,
     settings_style: SettingsStyle,
 
-    selected_nodes: Vec<Node<(), DefaultIx>>,
+    selected_nodes: Vec<Node<(), (), Directed, DefaultIx>>,
     selected_edges: Vec<Edge<(), DefaultIx>>,
     last_events: Vec<String>,
 
@@ -253,7 +253,8 @@ impl ConfigurableApp {
         self.g.g[idx].bind(idx, location);
 
         let n = self.g.g.node_weight_mut(idx).unwrap();
-        *n = n.with_label(format!("{:?}", idx));
+        n.set_label(format!("{:?}", idx));
+
         let mut sim_node = fdg_sim::Node::new(idx.index().to_string().as_str(), ());
         sim_node.location = Vec3::new(location.x, location.y, 0.);
         self.sim.get_graph_mut().add_node(sim_node);

--- a/examples/configurable/src/main.rs
+++ b/examples/configurable/src/main.rs
@@ -28,7 +28,7 @@ pub struct ConfigurableApp {
     settings_style: SettingsStyle,
 
     selected_nodes: Vec<Node<(), (), Directed, DefaultIx>>,
-    selected_edges: Vec<Edge<(), DefaultIx>>,
+    selected_edges: Vec<Edge<(), (), Directed>>,
     last_events: Vec<String>,
 
     simulation_stopped: bool,
@@ -589,13 +589,11 @@ impl App for ConfigurableApp {
             let settings_style = &egui_graphs::SettingsStyle::new()
                 .with_labels_always(self.settings_style.labels_always);
             ui.add(
-                &mut GraphView::<_, _, _, _, DefaultNodeShape, DefaultEdgeShape<_>>::new(
-                    &mut self.g,
-                )
-                .with_interactions(settings_interaction)
-                .with_navigations(settings_navigation)
-                .with_styles(settings_style)
-                .with_events(&self.event_publisher),
+                &mut GraphView::<_, _, _, _, DefaultNodeShape, DefaultEdgeShape>::new(&mut self.g)
+                    .with_interactions(settings_interaction)
+                    .with_navigations(settings_navigation)
+                    .with_styles(settings_style)
+                    .with_events(&self.event_publisher),
             );
         });
 

--- a/examples/custom_draw/README.md
+++ b/examples/custom_draw/README.md
@@ -1,5 +1,5 @@
 # Custom draw
-Example demonstrates how to use custom drawing functions for edge and nodes. Here we draw nodes as squares and adding edge labels for the standard edge shape.
+Example demonstrates how to use custom drawing functions for edge and nodes and handle animation state. Here we draw nodes as squares and adding edge labels for the standard edge shape. We also rotate node when it is in the state of dragging.
 
 ## run
 ```bash

--- a/examples/custom_draw/src/main.rs
+++ b/examples/custom_draw/src/main.rs
@@ -1,7 +1,7 @@
 use eframe::{run_native, App, CreationContext};
 use egui::Context;
 use egui_graphs::{DefaultEdgeShape, Graph, GraphView, SettingsInteraction, SettingsNavigation};
-use node::NodeShape;
+use node::NodeShapeAnimated;
 use petgraph::{
     stable_graph::{DefaultIx, StableGraph},
     Directed,
@@ -10,7 +10,7 @@ use petgraph::{
 mod node;
 
 pub struct CustomDrawApp {
-    g: Graph<(), (), Directed, DefaultIx, NodeShape>,
+    g: Graph<(), (), Directed, DefaultIx, NodeShapeAnimated>,
 }
 
 impl CustomDrawApp {
@@ -24,7 +24,7 @@ impl App for CustomDrawApp {
     fn update(&mut self, ctx: &Context, _: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.add(
-                &mut GraphView::<_, _, _, _, NodeShape, DefaultEdgeShape>::new(&mut self.g)
+                &mut GraphView::<_, _, _, _, NodeShapeAnimated, DefaultEdgeShape>::new(&mut self.g)
                     .with_navigations(
                         &SettingsNavigation::default()
                             .with_fit_to_screen_enabled(false)

--- a/examples/custom_draw/src/main.rs
+++ b/examples/custom_draw/src/main.rs
@@ -1,6 +1,8 @@
 use eframe::{run_native, App, CreationContext};
 use egui::Context;
-use egui_graphs::{DefaultEdgeShape, Graph, GraphView, SettingsInteraction, SettingsNavigation};
+use egui_graphs::{
+    DefaultEdgeShape, DisplayNode, Graph, GraphView, SettingsInteraction, SettingsNavigation,
+};
 use node::NodeShape;
 use petgraph::{
     stable_graph::{DefaultIx, StableGraph},
@@ -9,7 +11,7 @@ use petgraph::{
 
 mod node;
 
-pub struct CustomDrawApp {
+pub struct CustomDrawApp<D: DisplayNode> {
     g: Graph<(), (), Directed, DefaultIx>,
 }
 

--- a/examples/custom_draw/src/main.rs
+++ b/examples/custom_draw/src/main.rs
@@ -1,8 +1,6 @@
 use eframe::{run_native, App, CreationContext};
 use egui::Context;
-use egui_graphs::{
-    DefaultEdgeShape, DisplayNode, Graph, GraphView, SettingsInteraction, SettingsNavigation,
-};
+use egui_graphs::{DefaultEdgeShape, Graph, GraphView, SettingsInteraction, SettingsNavigation};
 use node::NodeShape;
 use petgraph::{
     stable_graph::{DefaultIx, StableGraph},
@@ -11,8 +9,8 @@ use petgraph::{
 
 mod node;
 
-pub struct CustomDrawApp<D: DisplayNode> {
-    g: Graph<(), (), Directed, DefaultIx>,
+pub struct CustomDrawApp {
+    g: Graph<(), (), Directed, DefaultIx, NodeShape>,
 }
 
 impl CustomDrawApp {
@@ -26,7 +24,7 @@ impl App for CustomDrawApp {
     fn update(&mut self, ctx: &Context, _: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.add(
-                &mut GraphView::<_, _, _, _, NodeShape, DefaultEdgeShape<_>>::new(&mut self.g)
+                &mut GraphView::<_, _, _, _, NodeShape, DefaultEdgeShape>::new(&mut self.g)
                     .with_navigations(
                         &SettingsNavigation::default()
                             .with_fit_to_screen_enabled(false)

--- a/examples/custom_draw/src/node.rs
+++ b/examples/custom_draw/src/node.rs
@@ -36,10 +36,7 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix> 
         find_intersection(self.loc, self.size + margin, dir)
     }
 
-    fn shapes<D: DisplayNode<N, E, Ty, Ix>>(
-        &self,
-        ctx: &egui_graphs::DrawContext<N, E, Ty, Ix, D>,
-    ) -> Vec<egui::Shape> {
+    fn shapes(&mut self, ctx: &egui_graphs::DrawContext) -> Vec<egui::Shape> {
         // lets draw a rect with label in the center for every node
 
         // find node center location on the screen coordinates

--- a/examples/custom_draw/src/node.rs
+++ b/examples/custom_draw/src/node.rs
@@ -1,56 +1,103 @@
-use egui::{epaint::TextShape, FontFamily, FontId, Pos2, Rect, Rounding, Shape, Stroke, Vec2};
+use std::time::Instant;
+
+use egui::{
+    emath::Rot2, epaint::TextShape, Color32, FontFamily, FontId, Pos2, Rect, Shape, Stroke, Vec2,
+};
 use egui_graphs::{DisplayNode, NodeProps};
 use petgraph::{stable_graph::IndexType, EdgeType};
 
+/// Rotates node whent the node is being dragged.
 #[derive(Clone)]
-pub struct NodeShape {
+pub struct NodeShapeAnimated {
     label: String,
     loc: Pos2,
-    selected: bool,
     dragged: bool,
+
+    angle_rad: f32,
+    speed_per_second: f32,
+    /// None means animation is not in progress
+    last_time_update: Option<Instant>,
 
     size: f32,
 }
 
-impl From<NodeProps> for NodeShape {
+impl From<NodeProps> for NodeShapeAnimated {
     fn from(node_props: NodeProps) -> Self {
         Self {
             label: node_props.label,
             loc: node_props.location,
-            selected: node_props.selected,
             dragged: node_props.dragged,
+
+            angle_rad: Default::default(),
+            last_time_update: Default::default(),
+            speed_per_second: 1.,
 
             size: 30.,
         }
     }
 }
 
-impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix> for NodeShape {
+impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix>
+    for NodeShapeAnimated
+{
     fn is_inside(&self, pos: Pos2) -> bool {
+        let rotated_pos = rotate_point_around(self.loc, pos, -self.angle_rad);
         let rect = Rect::from_center_size(self.loc, Vec2::new(self.size, self.size));
 
-        rect.contains(pos)
+        rect.contains(rotated_pos)
     }
+
     fn closest_boundary_point(&self, dir: Vec2) -> Pos2 {
-        let margin = 5.0;
-        find_intersection(self.loc, self.size + margin, dir)
+        let rotated_dir = rotate_vector(dir, -self.angle_rad);
+        let intersection_point = find_intersection(self.loc, self.size, rotated_dir);
+        rotate_point_around(self.loc, intersection_point, self.angle_rad)
     }
 
     fn shapes(&mut self, ctx: &egui_graphs::DrawContext) -> Vec<egui::Shape> {
         // lets draw a rect with label in the center for every node
+        // which rotates when the node is dragged
 
         // find node center location on the screen coordinates
         let center = ctx.meta.canvas_to_screen_pos(self.loc);
         let size = ctx.meta.canvas_to_screen_size(self.size);
-        let rect = Rect::from_center_size(center, Vec2::new(size, size));
+        let rect_default = Rect::from_center_size(center, Vec2::new(size, size));
+        let color = ctx.ctx.style().visuals.weak_text_color();
 
-        let interacted = self.selected || self.dragged;
-        let rect_color = match interacted {
-            true => ctx.ctx.style().visuals.selection.bg_fill,
-            false => ctx.ctx.style().visuals.weak_text_color(),
+        let diff = match self.dragged {
+            true => {
+                let now = Instant::now();
+                match self.last_time_update {
+                    Some(last_time) => {
+                        self.last_time_update = Some(now);
+                        let seconds_passed = now.duration_since(last_time);
+                        seconds_passed.as_secs_f32() * self.speed_per_second
+                    }
+                    None => {
+                        self.last_time_update = Some(now);
+                        0.
+                    }
+                }
+            }
+            false => {
+                if self.last_time_update.is_some() {
+                    self.last_time_update = None;
+                }
+                0.
+            }
         };
 
-        let shape_rect = Shape::rect_stroke(rect, Rounding::default(), Stroke::new(1., rect_color));
+        if diff > 0. {
+            let curr_angle = self.angle_rad + diff;
+            let rot = Rot2::from_angle(curr_angle).normalized();
+            self.angle_rad = rot.angle();
+        };
+
+        let points = rect_to_points(rect_default)
+            .into_iter()
+            .map(|p| rotate_point_around(center, p, self.angle_rad))
+            .collect::<Vec<_>>();
+
+        let shape_rect = Shape::convex_polygon(points, Color32::default(), Stroke::new(1., color));
 
         // create label
         let color = ctx.ctx.style().visuals.text_color();
@@ -66,9 +113,15 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix> 
         let offset = Vec2::new(-galley.size().x / 2., -galley.size().y / 2.);
 
         // create the shape and add it to the layers
-        let shape_label = TextShape::new(rect.center() + offset, galley);
+        let shape_label = TextShape::new(center + offset, galley);
 
         vec![shape_rect, shape_label.into()]
+    }
+
+    fn update(&mut self, state: &NodeProps) {
+        self.label = state.label.clone();
+        self.loc = state.location;
+        self.dragged = state.dragged;
     }
 }
 
@@ -93,6 +146,40 @@ fn find_intersection(center: Pos2, size: f32, direction: Vec2) -> Pos2 {
         let x = center.x + direction.x / direction.y * (y - center.y);
         Pos2::new(x, y)
     }
+}
+
+// Function to rotate a point around another point
+fn rotate_point_around(center: Pos2, point: Pos2, angle: f32) -> Pos2 {
+    let sin_angle = angle.sin();
+    let cos_angle = angle.cos();
+
+    // Translate point back to origin
+    let translated_point = point - center;
+
+    // Rotate point
+    let rotated_x = translated_point.x * cos_angle - translated_point.y * sin_angle;
+    let rotated_y = translated_point.x * sin_angle + translated_point.y * cos_angle;
+
+    // Translate point back
+    Pos2::new(rotated_x, rotated_y) + center.to_vec2()
+}
+
+fn rect_to_points(rect: Rect) -> Vec<Pos2> {
+    let top_left = rect.min;
+    let bottom_right = rect.max;
+
+    // Calculate the other two corners
+    let top_right = Pos2::new(bottom_right.x, top_left.y);
+    let bottom_left = Pos2::new(top_left.x, bottom_right.y);
+
+    vec![top_left, top_right, bottom_right, bottom_left]
+}
+
+/// rotates vector by angle
+fn rotate_vector(vec: Vec2, angle: f32) -> Vec2 {
+    let cos = angle.cos();
+    let sin = angle.sin();
+    Vec2::new(cos * vec.x - sin * vec.y, sin * vec.x + cos * vec.y)
 }
 
 #[cfg(test)]

--- a/examples/custom_draw/src/node.rs
+++ b/examples/custom_draw/src/node.rs
@@ -1,7 +1,8 @@
 use egui::{epaint::TextShape, FontFamily, FontId, Pos2, Rect, Rounding, Shape, Stroke, Vec2};
-use egui_graphs::{DisplayNode, Graph, Interactable, Node};
+use egui_graphs::{DisplayNode, NodeProps};
 use petgraph::{stable_graph::IndexType, EdgeType};
 
+#[derive(Clone)]
 pub struct NodeShape {
     label: String,
     loc: Pos2,
@@ -11,38 +12,34 @@ pub struct NodeShape {
     size: f32,
 }
 
-impl<N: Clone, Ix: IndexType> From<Node<N, Ix>> for NodeShape {
-    fn from(node: Node<N, Ix>) -> Self {
+impl From<NodeProps> for NodeShape {
+    fn from(node_props: NodeProps) -> Self {
         Self {
-            label: node.label(),
-            loc: node.location(),
-            selected: node.selected(),
-            dragged: node.dragged(),
+            label: node_props.label,
+            loc: node_props.location,
+            selected: node_props.selected,
+            dragged: node_props.dragged,
 
             size: 30.,
         }
     }
 }
 
-impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> Interactable<N, E, Ty, Ix> for NodeShape {
-    fn is_inside<Dn: egui_graphs::DisplayNode<N, E, Ty, Ix>>(
-        &self,
-        _g: &Graph<N, E, Ty, Ix>,
-        pos: Pos2,
-    ) -> bool {
+impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix> for NodeShape {
+    fn is_inside(&self, pos: Pos2) -> bool {
         let rect = Rect::from_center_size(self.loc, Vec2::new(self.size, self.size));
 
         rect.contains(pos)
     }
-}
-
-impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix> for NodeShape {
     fn closest_boundary_point(&self, dir: Vec2) -> Pos2 {
         let margin = 5.0;
         find_intersection(self.loc, self.size + margin, dir)
     }
 
-    fn shapes(&self, ctx: &egui_graphs::DrawContext<N, E, Ty, Ix>) -> Vec<egui::Shape> {
+    fn shapes<D: DisplayNode<N, E, Ty, Ix>>(
+        &self,
+        ctx: &egui_graphs::DrawContext<N, E, Ty, Ix, D>,
+    ) -> Vec<egui::Shape> {
         // lets draw a rect with label in the center for every node
 
         // find node center location on the screen coordinates

--- a/examples/interactive/src/main.rs
+++ b/examples/interactive/src/main.rs
@@ -32,11 +32,9 @@ impl App for InteractiveApp {
                 .with_edge_selection_multi_enabled(true);
             let style_settings = &SettingsStyle::new().with_labels_always(true);
             ui.add(
-                &mut GraphView::<_, _, _, _, DefaultNodeShape, DefaultEdgeShape<_>>::new(
-                    &mut self.g,
-                )
-                .with_styles(style_settings)
-                .with_interactions(interaction_settings),
+                &mut GraphView::<_, _, _, _, DefaultNodeShape, DefaultEdgeShape>::new(&mut self.g)
+                    .with_styles(style_settings)
+                    .with_interactions(interaction_settings),
             );
         });
     }

--- a/examples/undirected/src/main.rs
+++ b/examples/undirected/src/main.rs
@@ -26,7 +26,7 @@ impl App for UndirectedApp {
                 _,
                 _,
                 DefaultNodeShape,
-                DefaultEdgeShape<_>,
+                DefaultEdgeShape,
             >::new(&mut self.g));
         });
     }

--- a/src/computed.rs
+++ b/src/computed.rs
@@ -1,8 +1,9 @@
 use egui::{Rect, Vec2};
 use petgraph::graph::{EdgeIndex, IndexType};
 use petgraph::stable_graph::NodeIndex;
+use petgraph::EdgeType;
 
-use crate::Node;
+use crate::{DisplayNode, Node};
 
 /// The struct stores selections, dragged node and computed elements states.
 #[derive(Debug, Clone)]
@@ -37,7 +38,10 @@ impl<Ix> ComputedState<Ix>
 where
     Ix: IndexType,
 {
-    pub fn comp_iter_bounds<N: Clone>(&mut self, n: &Node<N, Ix>) {
+    pub fn comp_iter_bounds<N: Clone, E: Clone, Ty: EdgeType, D: DisplayNode<N, E, Ty, Ix>>(
+        &mut self,
+        n: &Node<N, E, Ty, Ix, D>,
+    ) {
         let loc = n.location();
         if loc.x < self.min.x {
             self.min.x = loc.x;

--- a/src/draw/default_edge.rs
+++ b/src/draw/default_edge.rs
@@ -6,14 +6,13 @@ use egui::{
 };
 use petgraph::{matrix_graph::Nullable, stable_graph::IndexType, EdgeType};
 
-use crate::{draw::DrawContext, elements::EdgeID, DisplayNode, Edge, Node};
+use crate::{draw::DrawContext, elements::EdgeProps, DisplayNode, Edge, Node};
 
 use super::DisplayEdge;
 
 #[derive(Clone, Debug)]
-pub struct DefaultEdgeShape<Ix: IndexType> {
-    pub edge_id: EdgeID<Ix>,
-
+pub struct DefaultEdgeShape {
+    pub order: usize,
     pub selected: bool,
 
     pub width: f32,
@@ -23,12 +22,11 @@ pub struct DefaultEdgeShape<Ix: IndexType> {
     pub loop_size: f32,
 }
 
-impl<E: Clone, Ix: IndexType> From<Edge<E, Ix>> for DefaultEdgeShape<Ix> {
-    fn from(edge: Edge<E, Ix>) -> Self {
+impl From<EdgeProps> for DefaultEdgeShape {
+    fn from(edge: EdgeProps) -> Self {
         Self {
-            edge_id: edge.id(),
-
-            selected: edge.selected(),
+            order: edge.order,
+            selected: edge.selected,
 
             width: 2.,
             tip_size: 15.,
@@ -40,7 +38,7 @@ impl<E: Clone, Ix: IndexType> From<Edge<E, Ix>> for DefaultEdgeShape<Ix> {
 }
 
 impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType, D: DisplayNode<N, E, Ty, Ix>>
-    DisplayEdge<N, E, Ty, Ix, D> for DefaultEdgeShape<Ix>
+    DisplayEdge<N, E, Ty, Ix, D> for DefaultEdgeShape
 {
     fn is_inside(
         &self,
@@ -176,11 +174,11 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType, D: DisplayNode<N, E, Ty, I
     }
 }
 
-fn shape_looped<Ix: IndexType>(
+fn shape_looped(
     node_size: f32,
     node_center: Pos2,
     stroke: Stroke,
-    e: &DefaultEdgeShape<Ix>,
+    e: &DefaultEdgeShape,
 ) -> CubicBezierShape {
     let center_horizon_angle = PI / 4.;
     let y_intersect = node_center.y - node_size * center_horizon_angle.sin();
@@ -207,13 +205,13 @@ fn shape_looped<Ix: IndexType>(
     )
 }
 
-fn shape_curved<Ix: IndexType>(
+fn shape_curved(
     pos_start: Pos2,
     pos_end: Pos2,
     size_start: f32,
     size_end: f32,
     stroke: Stroke,
-    e: &DefaultEdgeShape<Ix>,
+    e: &DefaultEdgeShape,
 ) -> QuadraticBezierShape {
     let vec = pos_end - pos_start;
     let dist: f32 = vec.length();
@@ -242,7 +240,7 @@ fn shape_curved<Ix: IndexType>(
 
 fn is_inside_loop<E: Clone, N: Clone, Ix: IndexType, Ty: EdgeType, D: DisplayNode<N, E, Ty, Ix>>(
     node: &Node<N, E, Ty, Ix, D>,
-    e: &DefaultEdgeShape<Ix>,
+    e: &DefaultEdgeShape,
     pos: Pos2,
 ) -> bool {
     let node_size = node_size(node);
@@ -255,7 +253,7 @@ fn is_inside_line<Ix: IndexType>(
     pos_start: Pos2,
     pos_end: Pos2,
     pos: Pos2,
-    e: &DefaultEdgeShape<Ix>,
+    e: &DefaultEdgeShape,
 ) -> bool {
     let distance = distance_segment_to_point(pos_start, pos_end, pos);
     distance <= e.width
@@ -270,7 +268,7 @@ fn is_inside_curve<
 >(
     node_start: &Node<N, E, Ty, Ix, D>,
     node_end: &Node<N, E, Ty, Ix, D>,
-    e: &DefaultEdgeShape<Ix>,
+    e: &DefaultEdgeShape,
     pos: Pos2,
 ) -> bool {
     let pos_start = node_start.location();

--- a/src/draw/default_edge.rs
+++ b/src/draw/default_edge.rs
@@ -54,7 +54,7 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType, D: DisplayNode<N, E, Ty, I
         let pos_end = end.location();
 
         if self.order == 0 {
-            return is_inside_line::<Ix>(pos_start, pos_end, pos, self);
+            return is_inside_line(pos_start, pos_end, pos, self);
         }
 
         is_inside_curve(start, end, self, pos)
@@ -171,6 +171,11 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType, D: DisplayNode<N, E, Ty, I
 
         vec![line_curved.into(), line_curved_tip]
     }
+
+    fn update(&mut self, state: &EdgeProps) {
+        self.order = state.order;
+        self.selected = state.selected;
+    }
 }
 
 fn shape_looped(
@@ -248,12 +253,7 @@ fn is_inside_loop<E: Clone, N: Clone, Ix: IndexType, Ty: EdgeType, D: DisplayNod
     is_point_on_cubic_bezier_curve(pos, shape, e.width)
 }
 
-fn is_inside_line<Ix: IndexType>(
-    pos_start: Pos2,
-    pos_end: Pos2,
-    pos: Pos2,
-    e: &DefaultEdgeShape,
-) -> bool {
+fn is_inside_line(pos_start: Pos2, pos_end: Pos2, pos: Pos2, e: &DefaultEdgeShape) -> bool {
     let distance = distance_segment_to_point(pos_start, pos_end, pos);
     distance <= e.width
 }

--- a/src/draw/default_edge.rs
+++ b/src/draw/default_edge.rs
@@ -6,7 +6,7 @@ use egui::{
 };
 use petgraph::{matrix_graph::Nullable, stable_graph::IndexType, EdgeType};
 
-use crate::{draw::DrawContext, elements::EdgeProps, DisplayNode, Edge, Node};
+use crate::{draw::DrawContext, elements::EdgeProps, DisplayNode, Node};
 
 use super::DisplayEdge;
 
@@ -53,8 +53,8 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType, D: DisplayNode<N, E, Ty, I
         let pos_start = start.location();
         let pos_end = end.location();
 
-        if self.edge_id.order == 0 {
-            return is_inside_line(pos_start, pos_end, pos, self);
+        if self.order == 0 {
+            return is_inside_line::<Ix>(pos_start, pos_end, pos, self);
         }
 
         is_inside_curve(start, end, self, pos)
@@ -96,7 +96,7 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType, D: DisplayNode<N, E, Ty, I
 
         let stroke_edge = Stroke::new(self.width * ctx.meta.zoom, color);
         let stroke_tip = Stroke::new(0., color);
-        if self.edge_id.order == 0 {
+        if self.order == 0 {
             // draw straight edge
 
             let line = Shape::line_segment(
@@ -131,9 +131,8 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType, D: DisplayNode<N, E, Ty, I
 
         let dir_perpendicular = Vec2::new(-dir.y, dir.x);
         let center_point = (edge_start + edge_end.to_vec2()).to_vec2() / 2.;
-        let control_point = (center_point
-            + dir_perpendicular * self.curve_size * self.edge_id.order as f32)
-            .to_pos2();
+        let control_point =
+            (center_point + dir_perpendicular * self.curve_size * self.order as f32).to_pos2();
 
         let tip_dir = (control_point - tip_end).normalized();
 
@@ -192,7 +191,7 @@ fn shape_looped(
         y_intersect,
     );
 
-    let loop_size = node_size * (e.loop_size + e.edge_id.order as f32);
+    let loop_size = node_size * (e.loop_size + e.order as f32);
 
     let control_point1 = Pos2::new(node_center.x + loop_size, node_center.y - loop_size);
     let control_point2 = Pos2::new(node_center.x - loop_size, node_center.y - loop_size);
@@ -228,7 +227,7 @@ fn shape_curved(
     let dir_perpendicular = Vec2::new(-dir.y, dir.x);
     let center_point = (edge_start + tip_end.to_vec2()).to_vec2() / 2.0;
     let control_point =
-        (center_point + dir_perpendicular * e.curve_size * e.edge_id.order as f32).to_pos2();
+        (center_point + dir_perpendicular * e.curve_size * e.order as f32).to_pos2();
 
     QuadraticBezierShape::from_points_stroke(
         [edge_start, control_point, edge_end],

--- a/src/draw/default_node.rs
+++ b/src/draw/default_node.rs
@@ -4,7 +4,7 @@ use egui::{
 };
 use petgraph::{stable_graph::IndexType, EdgeType};
 
-use crate::{draw::drawer::DrawContext, Graph, NodeProps};
+use crate::{draw::drawer::DrawContext, NodeProps};
 
 use super::DisplayNode;
 

--- a/src/draw/default_node.rs
+++ b/src/draw/default_node.rs
@@ -48,10 +48,7 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix>
         closest_point_on_circle(self.pos, self.radius, dir)
     }
 
-    fn shapes<D: DisplayNode<N, E, Ty, Ix>>(
-        &self,
-        ctx: &DrawContext<N, E, Ty, Ix, D>,
-    ) -> Vec<Shape> {
+    fn shapes(&mut self, ctx: &DrawContext) -> Vec<Shape> {
         let mut res = Vec::with_capacity(2);
 
         let is_interacted = self.selected || self.dragged;

--- a/src/draw/default_node.rs
+++ b/src/draw/default_node.rs
@@ -89,6 +89,14 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix>
 
         res
     }
+
+    fn update(&mut self, state: &NodeProps) {
+        self.pos = state.location;
+        self.pos = state.location;
+        self.selected = state.selected;
+        self.dragged = state.dragged;
+        self.label_text = state.label.to_string();
+    }
 }
 
 fn closest_point_on_circle(center: Pos2, radius: f32, dir: Vec2) -> Pos2 {

--- a/src/draw/default_node.rs
+++ b/src/draw/default_node.rs
@@ -4,9 +4,9 @@ use egui::{
 };
 use petgraph::{stable_graph::IndexType, EdgeType};
 
-use crate::{draw::drawer::DrawContext, Graph, Node};
+use crate::{draw::drawer::DrawContext, Graph, NodeProps};
 
-use super::{DisplayNode, Interactable};
+use super::DisplayNode;
 
 /// This is the default node shape which is used to display nodes in the graph.
 ///
@@ -24,41 +24,34 @@ pub struct DefaultNodeShape {
     pub radius: f32,
 }
 
-impl<N: Clone, Ix: IndexType> From<Node<N, Ix>> for DefaultNodeShape {
-    fn from(node: Node<N, Ix>) -> Self {
+impl From<NodeProps> for DefaultNodeShape {
+    fn from(node_props: NodeProps) -> Self {
         DefaultNodeShape {
-            pos: node.location(),
-
-            selected: node.selected(),
-            dragged: node.dragged(),
-
-            label_text: node.label().to_string(),
+            pos: node_props.location,
+            selected: node_props.selected,
+            dragged: node_props.dragged,
+            label_text: node_props.label.to_string(),
 
             radius: 5.0,
         }
     }
 }
 
-impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> Interactable<N, E, Ty, Ix>
-    for DefaultNodeShape
-{
-    fn is_inside<Nd: DisplayNode<N, E, Ty, Ix>>(
-        &self,
-        _g: &Graph<N, E, Ty, Ix>,
-        pos: Pos2,
-    ) -> bool {
-        is_inside_circle(self.pos, self.radius, pos)
-    }
-}
-
 impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix>
     for DefaultNodeShape
 {
+    fn is_inside(&self, pos: Pos2) -> bool {
+        is_inside_circle(self.pos, self.radius, pos)
+    }
+
     fn closest_boundary_point(&self, dir: Vec2) -> Pos2 {
         closest_point_on_circle(self.pos, self.radius, dir)
     }
 
-    fn shapes(&self, ctx: &DrawContext<N, E, Ty, Ix>) -> Vec<Shape> {
+    fn shapes<D: DisplayNode<N, E, Ty, Ix>>(
+        &self,
+        ctx: &DrawContext<N, E, Ty, Ix, D>,
+    ) -> Vec<Shape> {
         let mut res = Vec::with_capacity(2);
 
         let is_interacted = self.selected || self.dragged;

--- a/src/draw/displays.rs
+++ b/src/draw/displays.rs
@@ -1,7 +1,7 @@
 use egui::{Pos2, Shape, Vec2};
 use petgraph::{stable_graph::IndexType, EdgeType};
 
-use crate::{draw::drawer::DrawContext, Edge, Node, NodeProps};
+use crate::{draw::drawer::DrawContext, elements::EdgeProps, Edge, Node, NodeProps};
 
 pub trait DisplayNode<N, E, Ty, Ix>: Clone + From<NodeProps>
 where
@@ -34,7 +34,7 @@ where
     fn is_inside(&self, pos: Pos2) -> bool;
 }
 
-pub trait DisplayEdge<N, E, Ty, Ix, D>: From<Edge<E, Ix>>
+pub trait DisplayEdge<N, E, Ty, Ix, D>: Clone + From<EdgeProps>
 where
     N: Clone,
     E: Clone,
@@ -49,9 +49,9 @@ where
     /// * `ctx` - should be used to determine current global properties.
     /// * `start` and `end` - start and end points of the edge.
     ///
-    /// Use `ctx.meta` to properly scale and translate the shape.
+    /// Uses `ctx.meta` to properly scale and translate the shape.
     ///
-    /// Get [NodeGraphDisplay] from node endpoints to get start and end coordinates using [closest_boundary_point](NodeGraphDisplay::closest_boundary_point).
+    /// Uses [DisplayNode] implementation from node endpoints to get start and end coordinates using [closest_boundary_point](DisplayNode::closest_boundary_point).
     fn shapes(
         &mut self,
         start: &Node<N, E, Ty, Ix, D>,

--- a/src/draw/displays.rs
+++ b/src/draw/displays.rs
@@ -26,6 +26,9 @@ where
     /// Use `ctx.meta` to properly scale and translate the shape.
     fn shapes(&mut self, ctx: &DrawContext) -> Vec<Shape>;
 
+    /// Is called on every framte. Can be used for updating state of the implementation of [DisplayNode]
+    fn update(&mut self, state: &NodeProps);
+
     /// Checks if the provided `pos` is inside the shape.
     ///
     /// * `pos` - position is in the canvas coordinates.
@@ -58,6 +61,9 @@ where
         end: &Node<N, E, Ty, Ix, D>,
         ctx: &DrawContext,
     ) -> Vec<Shape>;
+
+    /// Is called on every frame. Can be used for updating state of the implementation of [DisplayNode]
+    fn update(&mut self, state: &EdgeProps);
 
     /// Checks if the provided `pos` is inside the shape.
     ///

--- a/src/draw/displays.rs
+++ b/src/draw/displays.rs
@@ -1,7 +1,7 @@
 use egui::{Pos2, Shape, Vec2};
 use petgraph::{stable_graph::IndexType, EdgeType};
 
-use crate::{draw::drawer::DrawContext, elements::EdgeProps, Edge, Node, NodeProps};
+use crate::{draw::drawer::DrawContext, elements::EdgeProps, Node, NodeProps};
 
 pub trait DisplayNode<N, E, Ty, Ix>: Clone + From<NodeProps>
 where

--- a/src/draw/displays.rs
+++ b/src/draw/displays.rs
@@ -19,13 +19,12 @@ where
 
     /// Draws shapes of the node.
     ///
+    /// Has mutable reference to itself for possibility to change internal state for the visualizations where this is important.
+    ///
     /// * `ctx` - should be used to determine current global properties.
     ///
     /// Use `ctx.meta` to properly scale and translate the shape.
-    fn shapes<D: DisplayNode<N, E, Ty, Ix>>(
-        &self,
-        ctx: &DrawContext<N, E, Ty, Ix, D>,
-    ) -> Vec<Shape>;
+    fn shapes(&mut self, ctx: &DrawContext) -> Vec<Shape>;
 
     /// Checks if the provided `pos` is inside the shape.
     ///
@@ -45,13 +44,20 @@ where
 {
     /// Draws shapes of the edge.
     ///
+    /// Has mutable reference to itself for possibility to change internal state for the visualizations where this is important.
+    ///
     /// * `ctx` - should be used to determine current global properties.
     /// * `start` and `end` - start and end points of the edge.
     ///
     /// Use `ctx.meta` to properly scale and translate the shape.
     ///
     /// Get [NodeGraphDisplay] from node endpoints to get start and end coordinates using [closest_boundary_point](NodeGraphDisplay::closest_boundary_point).
-    fn shapes(&self, ctx: &DrawContext<N, E, Ty, Ix, D>) -> Vec<Shape>;
+    fn shapes(
+        &mut self,
+        start: &Node<N, E, Ty, Ix, D>,
+        end: &Node<N, E, Ty, Ix, D>,
+        ctx: &DrawContext,
+    ) -> Vec<Shape>;
 
     /// Checks if the provided `pos` is inside the shape.
     ///

--- a/src/draw/drawer.rs
+++ b/src/draw/drawer.rs
@@ -28,7 +28,7 @@ where
 {
     p: Painter,
     ctx: &'a DrawContext<'a>,
-    g: &'a mut Graph<N, E, Ty, Ix, Nd>,
+    g: &'a mut Graph<N, E, Ty, Ix, Nd, Ed>,
     _marker: PhantomData<(Nd, Ed)>,
 }
 
@@ -41,7 +41,11 @@ where
     Nd: DisplayNode<N, E, Ty, Ix>,
     Ed: DisplayEdge<N, E, Ty, Ix, Nd>,
 {
-    pub fn new(p: Painter, g: &'a mut Graph<N, E, Ty, Ix, Nd>, ctx: &'a DrawContext<'a>) -> Self {
+    pub fn new(
+        p: Painter,
+        g: &'a mut Graph<N, E, Ty, Ix, Nd, Ed>,
+        ctx: &'a DrawContext<'a>,
+    ) -> Self {
         Drawer {
             p,
             ctx,
@@ -68,7 +72,12 @@ where
             .for_each(|idx| {
                 let n = self.g.node_mut(idx).unwrap();
 
-                let shapes = n.display_mut().shapes(self.ctx);
+                let props = n.props().clone();
+
+                let display = n.display_mut();
+                display.update(&props);
+
+                let shapes = display.shapes(self.ctx);
                 match n.selected() || n.dragged() {
                     true => shapes.into_iter().for_each(|s| l.add_top(s)),
                     false => shapes.into_iter().for_each(|s| l.add(s)),
@@ -91,7 +100,11 @@ where
 
                 let e = self.g.edge_mut(idx).unwrap();
 
-                let shapes = e.display_mut().shapes(&start, &end.clone(), self.ctx);
+                let props = e.props().clone();
+                let display = e.display_mut();
+                display.update(&props);
+
+                let shapes = display.shapes(&start, &end, self.ctx);
                 match e.selected() {
                     true => shapes.into_iter().for_each(|s| l.add_top(s)),
                     false => shapes.into_iter().for_each(|s| l.add(s)),

--- a/src/draw/drawer.rs
+++ b/src/draw/drawer.rs
@@ -84,13 +84,14 @@ where
             .into_iter()
             .for_each(|idx| {
                 let (idx_start, idx_end) = self.g.edge_endpoints(idx).unwrap();
-                let start = self.g.node(idx_start).unwrap();
-                let end = self.g.node(idx_end).unwrap();
+
+                // FIXME: not a good decision to clone nodes for every edge
+                let start = self.g.node(idx_start).cloned().unwrap();
+                let end = self.g.node(idx_end).cloned().unwrap();
 
                 let e = self.g.edge_mut(idx).unwrap();
 
-                let shapes =
-                    Ed::from(e.clone().clone()).shapes(start.clone(), end.clone(), self.ctx);
+                let shapes = e.display_mut().shapes(&start, &end.clone(), self.ctx);
                 match e.selected() {
                     true => shapes.into_iter().for_each(|s| l.add_top(s)),
                     false => shapes.into_iter().for_each(|s| l.add(s)),

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -8,4 +8,4 @@ pub use self::drawer::{DrawContext, Drawer};
 pub use self::layers::Layers;
 pub use default_edge::DefaultEdgeShape;
 pub use default_node::DefaultNodeShape;
-pub use displays::{DisplayEdge, DisplayNode, Interactable};
+pub use displays::{DisplayEdge, DisplayNode};

--- a/src/elements/edge.rs
+++ b/src/elements/edge.rs
@@ -59,6 +59,10 @@ impl<
         }
     }
 
+    pub fn props(&self) -> &EdgeProps {
+        &self.props
+    }
+
     /// Binds edge to the actual node ends and fixes its index in the set of duplicate edges.
     pub fn bind(&mut self, idx: EdgeIndex<Ix>, order: usize) {
         self.id = Some(idx);

--- a/src/elements/edge.rs
+++ b/src/elements/edge.rs
@@ -1,60 +1,77 @@
-use egui::{Color32, Context};
-use petgraph::stable_graph::{DefaultIx, EdgeIndex, IndexType};
+use petgraph::{
+    stable_graph::{DefaultIx, EdgeIndex, IndexType},
+    EdgeType,
+};
 
-/// Uniquely identifies edge with source, target and index in the set of duplicate edges.
+use crate::{DefaultEdgeShape, DefaultNodeShape, DisplayEdge, DisplayNode};
+
+/// Stores properties of an [Edge]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Clone, Debug)]
-pub struct EdgeID<Ix: IndexType = DefaultIx> {
-    pub idx: EdgeIndex<Ix>,
-
-    /// Index of the edge among siblings.
+#[derive(Clone, Debug, Default)]
+pub struct EdgeProps {
     pub order: usize,
-}
-
-impl<Ix: IndexType> EdgeID<Ix> {
-    pub fn new(idx: EdgeIndex<Ix>) -> Self {
-        Self {
-            idx,
-            order: Default::default(),
-        }
-    }
-
-    pub fn with_order(mut self, order: usize) -> Self {
-        self.order = order;
-        self
-    }
+    pub selected: bool,
 }
 
 /// Stores properties of an edge that can be changed. Used to apply changes to the graph.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]
-pub struct Edge<E: Clone, Ix: IndexType = DefaultIx> {
-    id: Option<EdgeID<Ix>>,
+pub struct Edge<
+    N: Clone,
+    E: Clone,
+    Ty: EdgeType,
+    Ix: IndexType = DefaultIx,
+    Dn: DisplayNode<N, E, Ty, Ix> = DefaultNodeShape,
+    D: DisplayEdge<N, E, Ty, Ix, Dn> = DefaultEdgeShape,
+> {
+    id: Option<EdgeIndex<Ix>>,
 
     /// Client data
     payload: E,
+    display: D,
 
-    selected: bool,
+    props: EdgeProps,
 }
 
-impl<E: Clone, Ix: IndexType> Edge<E, Ix> {
+impl<
+        N: Clone,
+        E: Clone,
+        Ty: EdgeType,
+        Ix: IndexType,
+        Dn: DisplayNode<N, E, Ty, Ix>,
+        D: DisplayEdge<N, E, Ty, Ix, Dn>,
+    > Edge<N, E, Ty, Ix, Dn, D>
+{
     pub fn new(payload: E) -> Self {
+        let props = EdgeProps::default();
+        let display = D::from(props);
         Self {
             payload,
 
+            props,
+            display,
+
             id: Default::default(),
-            selected: Default::default(),
         }
     }
 
-    /// Binds node to the actual node and position in the graph.
+    /// Binds edge to the actual node ends and fixes its index in the set of duplicate edges.
     pub fn bind(&mut self, idx: EdgeIndex<Ix>, order: usize) {
-        let id = EdgeID::new(idx).with_order(order);
+        let id = Some(idx);
         self.id = Some(id);
+        self.props.order = order;
     }
 
-    pub fn id(&self) -> EdgeID<Ix> {
-        self.id.clone().unwrap()
+    pub fn display(&self) -> &D {
+        &self.display
+    }
+
+    pub fn display_mut(&mut self) -> &mut D {
+        &mut self.display
+    }
+
+    pub fn id(&self) -> EdgeIndex<Ix> {
+        self.id.unwrap()
     }
 
     // TODO: handle unwrap
@@ -75,21 +92,11 @@ impl<E: Clone, Ix: IndexType> Edge<E, Ix> {
         &mut self.payload
     }
 
-    pub fn color(&self, ctx: &Context) -> Color32 {
-        if self.selected {
-            return ctx.style().visuals.widgets.hovered.fg_stroke.color;
-        }
-
-        ctx.style()
-            .visuals
-            .gray_out(ctx.style().visuals.widgets.inactive.fg_stroke.color)
-    }
-
     pub fn set_selected(&mut self, selected: bool) {
-        self.selected = selected;
+        self.props.selected = selected;
     }
 
     pub fn selected(&self) -> bool {
-        self.selected
+        self.props.selected
     }
 }

--- a/src/elements/edge.rs
+++ b/src/elements/edge.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use petgraph::{
     stable_graph::{DefaultIx, EdgeIndex, IndexType},
     EdgeType,
@@ -31,6 +33,7 @@ pub struct Edge<
     display: D,
 
     props: EdgeProps,
+    _marker: PhantomData<(N, Ty, Dn)>,
 }
 
 impl<
@@ -44,7 +47,7 @@ impl<
 {
     pub fn new(payload: E) -> Self {
         let props = EdgeProps::default();
-        let display = D::from(props);
+        let display = D::from(props.clone());
         Self {
             payload,
 
@@ -52,13 +55,13 @@ impl<
             display,
 
             id: Default::default(),
+            _marker: Default::default(),
         }
     }
 
     /// Binds edge to the actual node ends and fixes its index in the set of duplicate edges.
     pub fn bind(&mut self, idx: EdgeIndex<Ix>, order: usize) {
-        let id = Some(idx);
-        self.id = Some(id);
+        self.id = Some(idx);
         self.props.order = order;
     }
 
@@ -74,14 +77,12 @@ impl<
         self.id.unwrap()
     }
 
-    // TODO: handle unwrap
     pub fn order(&self) -> usize {
-        self.id.as_ref().unwrap().order
+        self.props.order
     }
 
-    // TODO: handle unwrap
     pub fn set_order(&mut self, order: usize) {
-        self.id.as_mut().unwrap().order = order;
+        self.props.order = order;
     }
 
     pub fn payload(&self) -> &E {

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -1,5 +1,5 @@
 mod edge;
 mod node;
 
-pub use self::edge::{Edge, EdgeID};
+pub use self::edge::{Edge, EdgeProps};
 pub use self::node::{Node, NodeProps};

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -2,4 +2,4 @@ mod edge;
 mod node;
 
 pub use self::edge::{Edge, EdgeID};
-pub use self::node::Node;
+pub use self::node::{Node, NodeProps};

--- a/src/elements/node.rs
+++ b/src/elements/node.rs
@@ -19,7 +19,7 @@ pub struct NodeProps {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Node<N, E, Ty, Ix = DefaultIx, D = DefaultNodeShape>
 where
     N: Clone,
@@ -35,6 +35,26 @@ where
     display: D,
 
     _marker: PhantomData<(E, Ty)>,
+}
+
+impl<N, E, Ty, Ix, D> Clone for Node<N, E, Ty, Ix, D>
+where
+    N: Clone,
+    E: Clone,
+    Ty: EdgeType,
+    Ix: IndexType,
+    D: DisplayNode<N, E, Ty, Ix>,
+{
+    fn clone(&self) -> Self {
+        let idx = self.id().index();
+        Self {
+            id: Some(NodeIndex::new(idx)),
+            payload: self.payload().clone(),
+            props: self.props.clone(),
+            display: self.display.clone(),
+            _marker: PhantomData,
+        }
+    }
 }
 
 impl<N, E, Ty, Ix, D> Node<N, E, Ty, Ix, D>

--- a/src/elements/node.rs
+++ b/src/elements/node.rs
@@ -1,37 +1,76 @@
+use std::marker::PhantomData;
+
 use egui::Pos2;
-use petgraph::stable_graph::{DefaultIx, IndexType, NodeIndex};
+use petgraph::{
+    stable_graph::{DefaultIx, IndexType, NodeIndex},
+    EdgeType,
+};
 
-/// Stores properties of a node.
+use crate::{DefaultNodeShape, DisplayNode};
+
+/// Stores properties of a [Node]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Clone, Debug)]
-pub struct Node<N: Clone, Ix: IndexType = DefaultIx> {
-    id: Option<NodeIndex<Ix>>,
-    location: Option<Pos2>,
-
-    payload: N,
-    label: String,
-
-    selected: bool,
-    dragged: bool,
+#[derive(Clone, Debug, Default)]
+pub struct NodeProps {
+    pub location: Pos2,
+    pub label: String,
+    pub selected: bool,
+    pub dragged: bool,
 }
 
-impl<N: Clone, Ix: IndexType> Node<N, Ix> {
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug)]
+pub struct Node<N, E, Ty, Ix = DefaultIx, D = DefaultNodeShape>
+where
+    N: Clone,
+    E: Clone,
+    Ty: EdgeType,
+    Ix: IndexType,
+    D: DisplayNode<N, E, Ty, Ix>,
+{
+    id: Option<NodeIndex<Ix>>,
+    payload: N,
+
+    props: NodeProps,
+    display: D,
+
+    _marker: PhantomData<(E, Ty)>,
+}
+
+impl<N, E, Ty, Ix, D> Node<N, E, Ty, Ix, D>
+where
+    N: Clone,
+    E: Clone,
+    Ty: EdgeType,
+    Ix: IndexType,
+    D: DisplayNode<N, E, Ty, Ix>,
+{
     pub fn new(payload: N) -> Self {
+        let props = NodeProps::default();
+        let display = D::from(props.clone());
         Self {
             payload,
+            props,
+            display,
 
             id: Default::default(),
-            location: Default::default(),
-            label: Default::default(),
-            selected: Default::default(),
-            dragged: Default::default(),
+            _marker: Default::default(),
         }
     }
 
+    pub fn display(&self) -> &D {
+        &self.display
+    }
+
+    pub fn display_mut(&mut self) -> &mut D {
+        &mut self.display
+    }
+
+    /// TODO: rethink this
     /// Binds node to the actual node and position in the graph.
     pub fn bind(&mut self, id: NodeIndex<Ix>, location: Pos2) {
         self.id = Some(id);
-        self.location = Some(location);
+        self.props.location = location;
     }
 
     // TODO: handle unbinded node
@@ -47,38 +86,35 @@ impl<N: Clone, Ix: IndexType> Node<N, Ix> {
         &mut self.payload
     }
 
-    // TODO: handle unbinded node
     pub fn location(&self) -> Pos2 {
-        self.location.unwrap()
+        self.props.location
     }
 
     pub fn set_location(&mut self, loc: Pos2) {
-        self.location = Some(loc)
+        self.props.location = loc
     }
 
     pub fn selected(&self) -> bool {
-        self.selected
+        self.props.selected
     }
 
     pub fn set_selected(&mut self, selected: bool) {
-        self.selected = selected;
+        self.props.selected = selected;
     }
 
     pub fn dragged(&self) -> bool {
-        self.dragged
+        self.props.dragged
     }
 
     pub fn set_dragged(&mut self, dragged: bool) {
-        self.dragged = dragged;
+        self.props.dragged = dragged;
     }
 
     pub fn label(&self) -> String {
-        self.label.clone()
+        self.props.label.clone()
     }
 
-    pub fn with_label(&mut self, label: String) -> Self {
-        let mut res = self.clone();
-        res.label = label;
-        res
+    pub fn set_label(&mut self, label: String) {
+        self.props.label = label
     }
 }

--- a/src/elements/node.rs
+++ b/src/elements/node.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use egui::Pos2;
@@ -19,7 +20,6 @@ pub struct NodeProps {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug)]
 pub struct Node<N, E, Ty, Ix = DefaultIx, D = DefaultNodeShape>
 where
     N: Clone,
@@ -35,6 +35,22 @@ where
     display: D,
 
     _marker: PhantomData<(E, Ty)>,
+}
+
+impl<N, E, Ty, Ix, D> Debug for Node<N, E, Ty, Ix, D>
+where
+    N: Clone,
+    E: Clone,
+    Ty: EdgeType,
+    Ix: IndexType,
+    D: DisplayNode<N, E, Ty, Ix>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut res = String::default();
+        res += format!("id : {:?}", self.id).as_str();
+        res += format!(", props: {:?}", self.props()).as_str();
+        f.write_str(format!("Node {{{}}}", res).as_str())
+    }
 }
 
 impl<N, E, Ty, Ix, D> Clone for Node<N, E, Ty, Ix, D>
@@ -76,6 +92,10 @@ where
             id: Default::default(),
             _marker: Default::default(),
         }
+    }
+
+    pub fn props(&self) -> &NodeProps {
+        &self.props
     }
 
     pub fn display(&self) -> &D {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -42,7 +42,7 @@ impl<
         Ix: IndexType,
         Dn: DisplayNode<N, E, Ty, Ix>,
         De: DisplayEdge<N, E, Ty, Ix, Dn>,
-    > Graph<N, E, Ty, Ix, Dn>
+    > Graph<N, E, Ty, Ix, Dn, De>
 {
     pub fn new(g: StableGraph<Node<N, E, Ty, Ix, Dn>, Edge<N, E, Ty, Ix, Dn, De>, Ty, Ix>) -> Self {
         Self { g }
@@ -71,7 +71,7 @@ impl<
             let (idx_start, idx_end) = self.g.edge_endpoints(e.id()).unwrap();
             let start = self.g.node_weight(idx_start).unwrap();
             let end = self.g.node_weight(idx_end).unwrap();
-            if De::from(e.clone()).is_inside(start, end, pos_in_graph) {
+            if e.display().is_inside(start, end, pos_in_graph) {
                 return Some(idx);
             }
         }
@@ -81,7 +81,7 @@ impl<
 
     pub fn g(
         &mut self,
-    ) -> &mut StableGraph<Node<N, E, Ty, Ix, Dn>, Edge<N, E, Ty, Ix, Dn>, Ty, Ix> {
+    ) -> &mut StableGraph<Node<N, E, Ty, Ix, Dn>, Edge<N, E, Ty, Ix, Dn, De>, Ty, Ix> {
         &mut self.g
     }
 
@@ -91,7 +91,7 @@ impl<
     }
 
     /// Provides iterator over all edges and their indices.
-    pub fn edges_iter(&self) -> impl Iterator<Item = (EdgeIndex<Ix>, &Edge<N, E, Ty, Ix, Dn>)> {
+    pub fn edges_iter(&self) -> impl Iterator<Item = (EdgeIndex<Ix>, &Edge<N, E, Ty, Ix, Dn, De>)> {
         self.g.edge_references().map(|e| (e.id(), e.weight()))
     }
 
@@ -99,7 +99,7 @@ impl<
         self.g.node_weight(i)
     }
 
-    pub fn edge(&self, i: EdgeIndex<Ix>) -> Option<&Edge<N, E, Ty, Ix, Dn>> {
+    pub fn edge(&self, i: EdgeIndex<Ix>) -> Option<&Edge<N, E, Ty, Ix, Dn, De>> {
         self.g.edge_weight(i)
     }
 
@@ -111,7 +111,7 @@ impl<
         self.g.node_weight_mut(i)
     }
 
-    pub fn edge_mut(&mut self, i: EdgeIndex<Ix>) -> Option<&mut Edge<N, E, Ty, Ix, Dn>> {
+    pub fn edge_mut(&mut self, i: EdgeIndex<Ix>) -> Option<&mut Edge<N, E, Ty, Ix, Dn, De>> {
         self.g.edge_weight_mut(i)
     }
 
@@ -127,7 +127,7 @@ impl<
         &self,
         idx: NodeIndex<Ix>,
         dir: Direction,
-    ) -> impl Iterator<Item = EdgeReference<Edge<N, E, Ty, Ix, Dn>, Ix>> {
+    ) -> impl Iterator<Item = EdgeReference<Edge<N, E, Ty, Ix, Dn, De>, Ix>> {
         self.g.edges_directed(idx, dir)
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -13,6 +13,9 @@ use crate::draw::{DisplayEdge, DisplayNode};
 use crate::{metadata::Metadata, transform, Edge, Node};
 use crate::{DefaultEdgeShape, DefaultNodeShape};
 
+type StableGraphType<N, E, Ty, Ix, Dn, De> =
+    StableGraph<Node<N, E, Ty, Ix, Dn>, Edge<N, E, Ty, Ix, Dn, De>, Ty, Ix>;
+
 /// Graph type compatible with [`super::GraphView`].
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone)]
@@ -24,7 +27,7 @@ pub struct Graph<
     Dn: DisplayNode<N, E, Ty, Ix> = DefaultNodeShape,
     De: DisplayEdge<N, E, Ty, Ix, Dn> = DefaultEdgeShape,
 > {
-    pub g: StableGraph<Node<N, E, Ty, Ix, Dn>, Edge<N, E, Ty, Ix, Dn, De>, Ty, Ix>,
+    pub g: StableGraphType<N, E, Ty, Ix, Dn, De>,
 }
 
 impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType, D: DisplayNode<N, E, Ty, Ix>>
@@ -44,21 +47,17 @@ impl<
         De: DisplayEdge<N, E, Ty, Ix, Dn>,
     > Graph<N, E, Ty, Ix, Dn, De>
 {
-    pub fn new(g: StableGraph<Node<N, E, Ty, Ix, Dn>, Edge<N, E, Ty, Ix, Dn, De>, Ty, Ix>) -> Self {
+    pub fn new(g: StableGraphType<N, E, Ty, Ix, Dn, De>) -> Self {
         Self { g }
     }
 
     /// Finds node by position. Can be optimized by using a spatial index like quad-tree if needed.
-    pub fn node_by_screen_pos(
-        &self,
-        meta: &Metadata,
-        screen_pos: Pos2,
-    ) -> Option<(NodeIndex<Ix>, &Node<N, E, Ty, Ix, Dn>)> {
+    pub fn node_by_screen_pos(&self, meta: &Metadata, screen_pos: Pos2) -> Option<NodeIndex<Ix>> {
         let pos_in_graph = meta.screen_to_canvas_pos(screen_pos);
         for (idx, node) in self.nodes_iter() {
             let display = node.display();
             if display.is_inside(pos_in_graph) {
-                return Some((idx, node));
+                return Some(idx);
             }
         }
         None
@@ -79,9 +78,7 @@ impl<
         None
     }
 
-    pub fn g(
-        &mut self,
-    ) -> &mut StableGraph<Node<N, E, Ty, Ix, Dn>, Edge<N, E, Ty, Ix, Dn, De>, Ty, Ix> {
+    pub fn g(&mut self) -> &mut StableGraphType<N, E, Ty, Ix, Dn, De> {
         &mut self.g
     }
 

--- a/src/graph_view.rs
+++ b/src/graph_view.rs
@@ -56,7 +56,7 @@ pub struct GraphView<
     Nd: DisplayNode<N, E, Ty, Ix>,
     Ed: DisplayEdge<N, E, Ty, Ix, Nd>,
 {
-    g: &'a mut Graph<N, E, Ty, Ix, Nd>,
+    g: &'a mut Graph<N, E, Ty, Ix, Nd, Ed>,
 
     settings_interaction: SettingsInteraction,
     settings_navigation: SettingsNavigation,
@@ -121,7 +121,7 @@ where
 {
     /// Creates a new `GraphView` widget with default navigation and interactions settings.
     /// To customize navigation and interactions use `with_interactions` and `with_navigations` methods.
-    pub fn new(g: &'a mut Graph<N, E, Ty, Ix, Dn>) -> Self {
+    pub fn new(g: &'a mut Graph<N, E, Ty, Ix, Dn, De>) -> Self {
         Self {
             g,
 

--- a/src/graph_view.rs
+++ b/src/graph_view.rs
@@ -89,12 +89,14 @@ where
         self.handle_node_drag(&resp, &mut computed, &mut meta);
         self.handle_click(&resp, &mut meta, &computed);
 
+        let is_directed = self.g.is_directed();
         Drawer::<N, E, Ty, Ix, Nd, Ed>::new(
             p,
+            &mut self.g,
             &DrawContext {
                 ctx: ui.ctx(),
-                g: self.g,
                 meta: &meta,
+                is_directed,
                 style: &self.settings_style,
             },
         )

--- a/src/graph_view.rs
+++ b/src/graph_view.rs
@@ -215,9 +215,7 @@ where
             return;
         }
 
-        let found_edge = self
-            .g
-            .edge_by_screen_pos::<De>(meta, resp.hover_pos().unwrap());
+        let found_edge = self.g.edge_by_screen_pos(meta, resp.hover_pos().unwrap());
         let found_node = self.g.node_by_screen_pos(meta, resp.hover_pos().unwrap());
         if found_node.is_none() && found_edge.is_none() {
             // click on empty space

--- a/src/graph_view.rs
+++ b/src/graph_view.rs
@@ -92,7 +92,7 @@ where
         let is_directed = self.g.is_directed();
         Drawer::<N, E, Ty, Ix, Nd, Ed>::new(
             p,
-            &mut self.g,
+            self.g,
             &DrawContext {
                 ctx: ui.ctx(),
                 meta: &meta,
@@ -233,16 +233,15 @@ where
             return;
         }
 
-        if let Some(n) = found_node {
+        if let Some(idx) = found_node {
             // first click of double click is handled by the lib as single click
             // so if you double click a node it will handle it as single click at first
             // and only after as double click
-            let node_idx = n.0;
             if resp.double_clicked() {
-                self.handle_node_double_click(node_idx);
+                self.handle_node_double_click(idx);
                 return;
             }
-            self.handle_node_click(node_idx, comp);
+            self.handle_node_click(idx, comp);
             return;
         }
 
@@ -328,7 +327,7 @@ where
         }
 
         if resp.drag_started() {
-            if let Some((idx, _)) = self.g.node_by_screen_pos(meta, resp.hover_pos().unwrap()) {
+            if let Some(idx) = self.g.node_by_screen_pos(meta, resp.hover_pos().unwrap()) {
                 self.set_drag_start(idx);
             }
         }

--- a/src/graph_view.rs
+++ b/src/graph_view.rs
@@ -47,7 +47,7 @@ pub struct GraphView<
     Ty = Directed,
     Ix = DefaultIx,
     Nd = DefaultNodeShape,
-    Ed = DefaultEdgeShape<Ix>,
+    Ed = DefaultEdgeShape,
 > where
     N: Clone,
     E: Clone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod settings;
 mod transform;
 
 pub use self::draw::{DefaultEdgeShape, DefaultNodeShape, DisplayEdge, DisplayNode, DrawContext};
-pub use self::elements::{Edge, EdgeID, Node, NodeProps};
+pub use self::elements::{Edge, Node, NodeProps};
 pub use self::graph::Graph;
 pub use self::graph_view::GraphView;
 pub use self::metadata::Metadata;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,8 @@ mod metadata;
 mod settings;
 mod transform;
 
-pub use self::draw::{
-    DefaultEdgeShape, DefaultNodeShape, DisplayEdge, DisplayNode, DrawContext, Interactable,
-};
-pub use self::elements::{Edge, Node};
+pub use self::draw::{DefaultEdgeShape, DefaultNodeShape, DisplayEdge, DisplayNode, DrawContext};
+pub use self::elements::{Edge, EdgeID, Node, NodeProps};
 pub use self::graph::Graph;
 pub use self::graph_view::GraphView;
 pub use self::metadata::Metadata;

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -116,7 +116,7 @@ pub fn add_edge_custom<
 /// let node2 = user_graph.add_node("B");
 /// user_graph.add_edge(node1, node2, "edge1");
 ///
-/// let input_graph = to_graph(&user_graph);
+/// let input_graph: egui_graphs::Graph<_, _, _, _, egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape> = to_graph(&user_graph);
 ///
 /// assert_eq!(input_graph.g.node_count(), 2);
 /// assert_eq!(input_graph.g.edge_count(), 1);

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -11,7 +11,8 @@ use std::collections::HashMap;
 
 pub const DEFAULT_SPAWN_SIZE: f32 = 250.;
 
-pub type EdgeTransform<E, Ix> = fn(EdgeIndex<Ix>, &E, usize) -> Edge<E, Ix>;
+pub type EdgeTransform<N, E, Ty, Ix, Dn, D> =
+    fn(EdgeIndex<Ix>, &E, usize) -> Edge<N, E, Ty, Ix, Dn, D>;
 pub type NodeTransform<N, E, Ty, Ix, D> = fn(NodeIndex<Ix>, &N) -> Node<N, E, Ty, Ix, D>;
 
 /// Helper function which adds user's node to the [`super::Graph`] instance.
@@ -60,7 +61,7 @@ pub fn add_edge_custom<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType>(
     start: NodeIndex<Ix>,
     end: NodeIndex<Ix>,
     e: &E,
-    edge_transform: EdgeTransform<E, Ix>,
+    edge_transform: EdgeTransform<N, E, Ty, Ix, Dn, D>,
 ) -> EdgeIndex<Ix> {
     let order = g.g.edges_connecting(start, end).count();
     g.g.add_edge(


### PR DESCRIPTION
Moving `DisplayNode` and `DisplayEdge` implementation inside of the elements to be able to preserve state of the shape. It can be crucial for animation or other state depending visualization.

This carries API changes with it.

Solves #122 

Changed custom draw example to demonstrate possible node animations approach.