### PR TITLE
Let `to_graph_custom` accept generic closures

### DIFF
--- a/src/draw/displays.rs
+++ b/src/draw/displays.rs
@@ -26,7 +26,7 @@ where
     /// Use `ctx.meta` to properly scale and translate the shape.
     fn shapes(&mut self, ctx: &DrawContext) -> Vec<Shape>;
 
-    /// Is called on every framte. Can be used for updating state of the implementation of [DisplayNode]
+    /// Is called on every frame. Can be used for updating state of the implementation of [DisplayNode]
     fn update(&mut self, state: &NodeProps<N>);
 
     /// Checks if the provided `pos` is inside the shape.


### PR DESCRIPTION
This PR lets `egui_graphs::to_graph_custom` accept generic functions and closures.

This was still possible in `0.15`, but unfortunately, starting from `0.16` it only accepts bare function pointers. This has the downside that it's no longer possible to reference external state while transforming a graph. Well, unless you hack something together using global variables but I was unwilling to go that route 😉.