### PR TITLE
derive Serialize and Deserialize for BoundsIterator

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,6 +2,11 @@ use egui::{Id, Pos2, Rect, Vec2};
 use petgraph::{stable_graph::IndexType, EdgeType};
 
 use crate::{DisplayNode, Node};
+
+#[cfg_attr(
+    feature = "egui_persistence",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[derive(Clone, Debug)]
 struct BoundsIterator {
     min: Vec2,
@@ -77,10 +82,7 @@ impl Default for Metadata {
 
 impl Metadata {
     pub fn get(ui: &egui::Ui) -> Self {
-        ui.data_mut(|data| {
-            data.get_persisted::<Metadata>(Id::NULL)
-                .unwrap_or_default()
-        })
+        ui.data_mut(|data| data.get_persisted::<Metadata>(Id::NULL).unwrap_or_default())
     }
 
     pub fn store_into_ui(self, ui: &mut egui::Ui) {


### PR DESCRIPTION
The crate does not compile with the `egui_persistence` feature because `BoundsIterator` does not implement `Serialize` and `Deserialize`.

`BoundsIterator` is used by the `Metadata` struct which does derive both traits.
```rs
#[cfg_attr(
    feature = "egui_persistence",
    derive(serde::Serialize, serde::Deserialize)
)]
#[derive(Clone, Debug)]
pub struct Metadata {
    /// Whether the frame is the first one
    pub first_frame: bool,
    /// Current zoom factor
    pub zoom: f32,
    /// Current pan offset
    pub pan: Vec2,
    /// Top left position of widget
    pub top_left: Pos2,

    /// State of bounds iteration
    bounds_iterator: BoundsIterator,
}
```

```
egui_graphs = { version = "0.17.0", features = ["egui_persistence", "serde"] }
```

The error:
```console
error[E0277]: the trait bound `BoundsIterator: Deserialize<'_>` is not satisfied
    --> /home/bruno/.cargo/registry/src/index.crates.io-6f17d22bba15001f/egui_graphs-0.17.0/src/metadata.rs:63:22
     |
63   |     bounds_iterator: BoundsIterator,
     |                      ^^^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `BoundsIterator`
     |
     = help: the following other types implement trait `Deserialize<'de>`:
               bool
               char
               isize
               i8
               i16
               i32
               i64
               i128
             and 297 others
note: required by a bound in `next_element`
```