### PR TITLE
add update_display_from_props methods to Node and Edge

### DIFF
--- a/src/draw/drawer.rs
+++ b/src/draw/drawer.rs
@@ -70,10 +70,9 @@ where
             .into_iter()
             .for_each(|idx| {
                 let n = self.g.node_mut(idx).unwrap();
-                let props = n.props().clone();
+                n.update_display_from_props();
 
                 let display = n.display_mut();
-                display.update(&props);
                 let shapes = display.shapes(self.ctx);
 
                 if n.selected() || n.dragged() {
@@ -102,10 +101,9 @@ where
                 let end = self.g.node(idx_end).cloned().unwrap();
 
                 let e = self.g.edge_mut(idx).unwrap();
-                let props = e.props().clone();
+                e.update_display_from_props();
 
                 let display = e.display_mut();
-                display.update(&props);
                 let shapes = display.shapes(&start, &end, self.ctx);
 
                 if e.selected() {

--- a/src/elements/edge.rs
+++ b/src/elements/edge.rs
@@ -82,6 +82,10 @@ impl<
         &mut self.display
     }
 
+    pub fn update_display_from_props(&mut self) {
+        self.display.update(&self.props);
+    }
+
     pub fn id(&self) -> EdgeIndex<Ix> {
         self.id.unwrap()
     }

--- a/src/elements/node.rs
+++ b/src/elements/node.rs
@@ -108,6 +108,10 @@ where
         &mut self.display
     }
 
+    pub fn update_display_from_props(&mut self) {
+        self.display.update(&self.props);
+    }
+
     /// TODO: rethink this
     /// Binds node to the actual node and position in the graph.
     pub fn bind(&mut self, id: NodeIndex<Ix>, location: Pos2) {


### PR DESCRIPTION
This avoids cloning props unnecessarily.

Related to #172