### PR TITLE
Update nodes before drawing edges

### DIFF
--- a/src/draw/drawer.rs
+++ b/src/draw/drawer.rs
@@ -70,10 +70,9 @@ where
             .into_iter()
             .for_each(|idx| {
                 let n = self.g.node_mut(idx).unwrap();
-                let props = n.props().clone();
+                n.update_display_from_props();
 
                 let display = n.display_mut();
-                display.update(&props);
                 let shapes = display.shapes(self.ctx);
 
                 if n.selected() || n.dragged() {
@@ -102,10 +101,9 @@ where
                 let end = self.g.node(idx_end).cloned().unwrap();
 
                 let e = self.g.edge_mut(idx).unwrap();
-                let props = e.props().clone();
+                e.update_display_from_props();
 
                 let display = e.display_mut();
-                display.update(&props);
                 let shapes = display.shapes(&start, &end, self.ctx);
 
                 if e.selected() {

--- a/src/draw/drawer.rs
+++ b/src/draw/drawer.rs
@@ -58,8 +58,21 @@ where
     }
 
     pub fn draw(mut self) {
+        // Update nodes first so that their position is correct when drawing edges.
+        self.update_nodes();
         self.draw_edges();
         self.fill_layers_nodes();
+    }
+
+    fn update_nodes(&mut self) {
+        self.g
+            .g
+            .node_indices()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .for_each(|idx| {
+                self.g.node_mut(idx).unwrap().update_display_from_props();
+            });
     }
 
     fn fill_layers_nodes(&mut self) {
@@ -70,8 +83,7 @@ where
             .into_iter()
             .for_each(|idx| {
                 let n = self.g.node_mut(idx).unwrap();
-                n.update_display_from_props();
-
+                // nodes have already been updated so don't need to update them here.
                 let display = n.display_mut();
                 let shapes = display.shapes(self.ctx);
 

--- a/src/elements/edge.rs
+++ b/src/elements/edge.rs
@@ -82,6 +82,10 @@ impl<
         &mut self.display
     }
 
+    pub fn update_display_from_props(&mut self) {
+        self.display.update(&self.props);
+    }
+
     pub fn id(&self) -> EdgeIndex<Ix> {
         self.id.unwrap()
     }

--- a/src/elements/node.rs
+++ b/src/elements/node.rs
@@ -108,6 +108,10 @@ where
         &mut self.display
     }
 
+    pub fn update_display_from_props(&mut self) {
+        self.display.update(&self.props);
+    }
+
     /// TODO: rethink this
     /// Binds node to the actual node and position in the graph.
     pub fn bind(&mut self, id: NodeIndex<Ix>, location: Pos2) {


### PR DESCRIPTION
This PR includes #173 for convenience, though you might not want this so I made them separate PRs. 

Fixes #172 so the user doesn't need to call update_display_from_props when adding a node.