### PR TITLE
fix bad unwrap in graph_view for hover_pos

### DIFF
--- a/src/graph_view.rs
+++ b/src/graph_view.rs
@@ -219,8 +219,12 @@ where
             return;
         }
 
-        let found_edge = self.g.edge_by_screen_pos(meta, resp.hover_pos().unwrap());
-        let found_node = self.g.node_by_screen_pos(meta, resp.hover_pos().unwrap());
+        let cursor_pos = match resp.hover_pos() {
+            Some(pos) => pos,
+            None => return,
+        };
+        let found_edge = self.g.edge_by_screen_pos(meta, cursor_pos);
+        let found_node = self.g.node_by_screen_pos(meta, cursor_pos);
         if found_node.is_none() && found_edge.is_none() {
             // click on empty space
             let nodes_selectable = self.settings_interaction.node_selection_enabled


### PR DESCRIPTION
This caused a panic for me when switched to the graph view in my app. It tried to load a lot of nodes at once (called amongst UI code). Might have been related to clicking on the app while it was loading, then moving my cursor off, and when the event was processed there was no hover_pos. (It returns None if the cursor is outside the window)