### PR TITLE
Fix missing turbofish in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ impl App for BasicApp {
                 _,
                 DefaultNodeShape,
                 DefaultEdgeShape,
-            >new(&mut self.g));
+            >::new(&mut self.g));
         });
     }
 }


### PR DESCRIPTION
Examples in the readme should be valid rust so that users can copy them directly.