### PR TITLE
Default label value + demo refactor

### DIFF
--- a/examples/demo/src/drawers.rs
+++ b/examples/demo/src/drawers.rs
@@ -1,13 +1,60 @@
 use egui::Ui;
 
-pub struct ValuesGraphConfigSliders {
+pub struct ValuesConfigButtonsStartReset {
+    pub simulation_stopped: bool,
+}
+
+pub fn draw_start_reset_buttons(
+    ui: &mut egui::Ui,
+    mut values: ValuesConfigButtonsStartReset,
+    mut on_change: impl FnMut(bool, bool),
+) {
+    ui.vertical(|ui| {
+        ui.label("Stop or start simulation again or reset to default settings.");
+        ui.horizontal(|ui| {
+            let start_simulation_stopped = values.simulation_stopped;
+            if ui
+                .button(match values.simulation_stopped {
+                    true => "start",
+                    false => "stop",
+                })
+                .clicked()
+            {
+                values.simulation_stopped = !values.simulation_stopped;
+            };
+
+            let mut reset_pressed = false;
+            if ui.button("reset").clicked() {
+                reset_pressed = true;
+            }
+
+            if start_simulation_stopped != values.simulation_stopped || reset_pressed {
+                on_change(values.simulation_stopped, reset_pressed);
+            }
+        });
+    });
+}
+
+pub struct ValuesSectionDebug {
+    pub zoom: f32,
+    pub pan: [f32; 2],
+    pub fps: f32,
+}
+
+pub fn draw_section_debug(ui: &mut egui::Ui, values: ValuesSectionDebug) {
+    ui.label(format!("zoom: {:.5}", values.zoom));
+    ui.label(format!("pan: [{:.5}, {:.5}]", values.pan[0], values.pan[1]));
+    ui.label(format!("FPS: {:.1}", values.fps));
+}
+
+pub struct ValuesConfigSlidersGraph {
     pub node_cnt: usize,
     pub edge_cnt: usize,
 }
 
 pub fn draw_counts_sliders(
     ui: &mut egui::Ui,
-    mut values: ValuesGraphConfigSliders,
+    mut values: ValuesConfigSlidersGraph,
     mut on_change: impl FnMut(i32, i32),
 ) {
     let start_node_cnt = values.node_cnt;
@@ -37,7 +84,7 @@ pub fn draw_counts_sliders(
     };
 }
 
-pub struct ValuesSimulationConfigSliders {
+pub struct ValuesConfigSlidersSimulation {
     pub dt: f32,
     pub cooloff_factor: f32,
     pub scale: f32,
@@ -45,7 +92,7 @@ pub struct ValuesSimulationConfigSliders {
 
 pub fn draw_simulation_config_sliders(
     ui: &mut Ui,
-    mut values: ValuesSimulationConfigSliders,
+    mut values: ValuesConfigSlidersSimulation,
     mut on_change: impl FnMut(f32, f32, f32),
 ) {
     let start_dt = values.dt;

--- a/examples/demo/src/drawers.rs
+++ b/examples/demo/src/drawers.rs
@@ -1,0 +1,87 @@
+use egui::Ui;
+
+pub struct ValuesGraphConfigSliders {
+    pub node_cnt: usize,
+    pub edge_cnt: usize,
+}
+
+pub fn draw_counts_sliders(
+    ui: &mut egui::Ui,
+    mut values: ValuesGraphConfigSliders,
+    mut on_change: impl FnMut(i32, i32),
+) {
+    let start_node_cnt = values.node_cnt;
+    let mut delta_node_cnt = 0;
+    ui.horizontal(|ui| {
+        if ui
+            .add(egui::Slider::new(&mut values.node_cnt, 1..=2500).text("nodes"))
+            .changed()
+        {
+            delta_node_cnt = values.node_cnt as i32 - start_node_cnt as i32;
+        };
+    });
+
+    let start = values.edge_cnt;
+    let mut delta_edge_cnt = 0;
+    ui.horizontal(|ui| {
+        if ui
+            .add(egui::Slider::new(&mut values.edge_cnt, 1..=2500).text("edges"))
+            .changed()
+        {
+            delta_edge_cnt = values.edge_cnt as i32 - start as i32;
+        };
+    });
+
+    if delta_node_cnt != 0 || delta_edge_cnt != 0 {
+        on_change(delta_node_cnt, delta_edge_cnt)
+    };
+}
+
+pub struct ValuesSimulationConfigSliders {
+    pub dt: f32,
+    pub cooloff_factor: f32,
+    pub scale: f32,
+}
+
+pub fn draw_simulation_config_sliders(
+    ui: &mut Ui,
+    mut values: ValuesSimulationConfigSliders,
+    mut on_change: impl FnMut(f32, f32, f32),
+) {
+    let start_dt = values.dt;
+    let mut delta_dt = 0.;
+    ui.horizontal(|ui| {
+        if ui
+            .add(egui::Slider::new(&mut values.dt, 0.00..=1.).text("dt"))
+            .changed()
+        {
+            delta_dt = values.dt - start_dt;
+        };
+    });
+
+    let start_cooloff_factor = values.cooloff_factor;
+    let mut delta_cooloff_factor = 0.;
+    ui.horizontal(|ui| {
+        if ui
+            .add(egui::Slider::new(&mut values.cooloff_factor, 0.00..=1.).text("cooloff_factor"))
+            .changed()
+        {
+            delta_cooloff_factor = values.cooloff_factor - start_cooloff_factor;
+        };
+    });
+
+    let start_scale = values.scale;
+    let mut delta_scale = 0.;
+    ui.horizontal(|ui| {
+        if ui
+            .add(egui::Slider::new(&mut values.scale, 1.0..=1000.).text("scale"))
+            .changed()
+        {
+            delta_scale = values.scale - start_scale;
+        };
+    });
+
+    if delta_dt != 0. || delta_cooloff_factor != 0. || delta_scale != 0. {
+        on_change(delta_dt, delta_cooloff_factor, delta_scale);
+    }
+}

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use crossbeam::channel::{unbounded, Receiver, Sender};
 use eframe::{run_native, App, CreationContext};
-use egui::{CollapsingHeader, Context, Pos2, ScrollArea, Slider, Ui, Vec2};
+use egui::{CollapsingHeader, Context, Pos2, ScrollArea, Ui, Vec2};
 use egui_graphs::events::Event;
 use egui_graphs::{to_graph, DefaultEdgeShape, DefaultNodeShape, Edge, Graph, GraphView, Node};
 use fdg::fruchterman_reingold::{FruchtermanReingold, FruchtermanReingoldConfiguration};

--- a/examples/demo/src/settings.rs
+++ b/examples/demo/src/settings.rs
@@ -6,8 +6,8 @@ pub struct SettingsGraph {
 impl Default for SettingsGraph {
     fn default() -> Self {
         Self {
-            count_node: 300,
-            count_edge: 500,
+            count_node: 25,
+            count_edge: 50,
         }
     }
 }
@@ -56,7 +56,7 @@ impl Default for SettingsSimulation {
     fn default() -> Self {
         Self {
             dt: 0.03,
-            cooloff_factor: 0.7,
+            cooloff_factor: 0.85,
             scale: 100.,
         }
     }

--- a/examples/demo/src/settings.rs
+++ b/examples/demo/src/settings.rs
@@ -45,3 +45,19 @@ impl Default for SettingsNavigation {
 pub struct SettingsStyle {
     pub labels_always: bool,
 }
+
+pub struct SettingsSimulation {
+    pub dt: f32,
+    pub cooloff_factor: f32,
+    pub scale: f32,
+}
+
+impl Default for SettingsSimulation {
+    fn default() -> Self {
+        Self {
+            dt: 0.03,
+            cooloff_factor: 0.7,
+            scale: 100.,
+        }
+    }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -118,7 +118,7 @@ impl<
         let graph_node = self.g.node_weight_mut(idx).unwrap();
 
         graph_node.bind(idx, location);
-        graph_node.set_label(idx.index().to_string());
+        graph_node.set_label(format!("node {}", idx.index()));
 
         idx
     }
@@ -178,7 +178,7 @@ impl<
         removed
     }
 
-    /// Adds edge between start and end node with default label setting correct order.
+    /// Adds edge between start and end node with default label.
     pub fn add_edge(
         &mut self,
         start: NodeIndex<Ix>,
@@ -191,7 +191,7 @@ impl<
         let e = self.g.edge_weight_mut(idx).unwrap();
 
         e.bind(idx, order);
-        e.set_label(e.id().index().to_string());
+        e.set_label(format!("edge {}", e.id().index()));
 
         idx
     }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -125,8 +125,8 @@ pub fn add_edge_custom<
 ///
 /// assert_eq!(*input_graph.g.edge_weight(input_graph.g.edge_indices().next().unwrap()).unwrap().payload(), "edge1");
 ///
-/// assert_eq!(*input_graph.g.node_weight(input_node_1).unwrap().label().clone(), input_node_1.index().to_string());
-/// assert_eq!(*input_graph.g.node_weight(input_node_2).unwrap().label().clone(), input_node_2.index().to_string());
+/// assert_eq!(*input_graph.g.node_weight(input_node_1).unwrap().label().clone(), format!("node {}", input_node_1.index()));
+/// assert_eq!(*input_graph.g.node_weight(input_node_2).unwrap().label().clone(), format!("node {}", input_node_2.index()));
 ///
 /// let loc_1 = input_graph.g.node_weight(input_node_1).unwrap().location();
 /// let loc_2 = input_graph.g.node_weight(input_node_2).unwrap().location();
@@ -175,7 +175,7 @@ pub fn default_node_transform<
     payload: &N,
 ) -> Node<N, E, Ty, Ix, D> {
     let mut n = Node::new(payload.clone());
-    n.set_label(idx.index().to_string());
+    n.set_label(format!("node {}", idx.index()));
 
     let loc = random_location(DEFAULT_SPAWN_SIZE);
     n.bind(idx, loc);
@@ -197,7 +197,7 @@ pub fn default_edge_transform<
 ) -> Edge<N, E, Ty, Ix, Dn, D> {
     let mut e = Edge::new(payload.clone());
     e.bind(idx, order);
-    e.set_label(e.id().index().to_string());
+    e.set_label(format!("edge {}", e.id().index()));
     e
 }
 
@@ -280,7 +280,7 @@ mod tests {
             assert!(input_n.location().x >= 0.0 && input_n.location().x <= DEFAULT_SPAWN_SIZE);
             assert!(input_n.location().y >= 0.0 && input_n.location().y <= DEFAULT_SPAWN_SIZE);
 
-            assert_eq!(*input_n.label(), user_idx.index().to_string());
+            assert_eq!(*input_n.label(), format!("node {}", user_idx.index()));
 
             assert!(!input_n.selected());
             assert!(!input_n.dragged());
@@ -309,7 +309,7 @@ mod tests {
             assert!(input_n.location().x >= 0.0 && input_n.location().x <= DEFAULT_SPAWN_SIZE);
             assert!(input_n.location().y >= 0.0 && input_n.location().y <= DEFAULT_SPAWN_SIZE);
 
-            assert_eq!(*input_n.label(), user_idx.index().to_string());
+            assert_eq!(*input_n.label(), format!("node {}", user_idx.index()));
 
             assert!(!input_n.selected());
             assert!(!input_n.dragged());


### PR DESCRIPTION
- default label value changed from `id` for nodes and edges to  `node <id>` or `edge <id>`
- extracted drawers and settings into separate modules