### PR TITLE
Replace rand with fastrand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["gui", "visualization"]
 egui = { version = "0.31.0", default-features = false, features = [
   "persistence",
 ] }
-rand = "0.9"
+fastrand = "2.3"
 petgraph = { version = "0.8", default-features = false, features = [
   "graphmap",
   "stable_graph",

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -13,5 +13,5 @@ serde_json = "1.0"
 petgraph = "0.7"
 # TODO: need to implement fdg to upgrade to newer petgraph and egui_graphs
 fdg = { git = "https://github.com/grantshandy/fdg" }
-rand = "0.9"
+fastrand = "2.3"
 crossbeam = "0.8"

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -11,7 +11,6 @@ use fdg::nalgebra::{Const, OPoint};
 use fdg::{Force, ForceGraph};
 use petgraph::stable_graph::{DefaultIx, EdgeIndex, NodeIndex};
 use petgraph::Directed;
-use rand::Rng;
 
 mod drawers;
 mod settings;
@@ -150,7 +149,7 @@ impl DemoApp {
             return None;
         }
 
-        let random_n_idx = rand::rng().random_range(0..nodes_cnt);
+        let random_n_idx = fastrand::usize(0..nodes_cnt);
         self.g.g.node_indices().nth(random_n_idx)
     }
 
@@ -160,7 +159,7 @@ impl DemoApp {
             return None;
         }
 
-        let random_e_idx = rand::rng().random_range(0..edges_cnt);
+        let random_e_idx = fastrand::usize(0..edges_cnt);
         self.g.g.edge_indices().nth(random_e_idx)
     }
 
@@ -178,10 +177,10 @@ impl DemoApp {
         let random_n = self.g.node(random_n_idx.unwrap()).unwrap();
 
         // location of new node is in in the closest surrounding of random existing node
-        let mut rng = rand::rng();
+        let mut rng = fastrand::Rng::new();
         let location = Pos2::new(
-            random_n.location().x + 10. + rng.random_range(0. ..50.),
-            random_n.location().y + 10. + rng.random_range(0. ..50.),
+            random_n.location().x + 10. + 50. * rng.f32(),
+            random_n.location().y + 10. + 50. * rng.f32(),
         );
 
         let g_idx = self.g.add_node_with_location((), location);

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,7 +6,6 @@ use petgraph::{
     visit::IntoNodeReferences,
     EdgeType,
 };
-use rand::Rng;
 use std::collections::HashMap;
 
 /// Helper function which adds user's node to the [`super::Graph`] instance.
@@ -217,7 +216,7 @@ pub fn node_size<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType, D: DisplayNode
 }
 
 pub fn random_graph(num_nodes: usize, num_edges: usize) -> Graph {
-    let mut rng = rand::rng();
+    let mut rng = fastrand::Rng::new();
     let mut graph = StableGraph::new();
 
     for _ in 0..num_nodes {
@@ -225,8 +224,8 @@ pub fn random_graph(num_nodes: usize, num_edges: usize) -> Graph {
     }
 
     for _ in 0..num_edges {
-        let source = rng.random_range(0..num_nodes);
-        let target = rng.random_range(0..num_nodes);
+        let source = rng.usize(0..num_nodes);
+        let target = rng.usize(0..num_nodes);
 
         graph.add_edge(NodeIndex::new(source), NodeIndex::new(target), ());
     }

--- a/src/layouts/random/layout.rs
+++ b/src/layouts/random/layout.rs
@@ -1,6 +1,5 @@
 use egui::Pos2;
 use petgraph::stable_graph::IndexType;
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -36,12 +35,9 @@ impl Layout<State> for Random {
             return;
         }
 
-        let mut rng = rand::rng();
+        let mut rng = fastrand::Rng::new();
         for node in g.g.node_weights_mut() {
-            node.set_location(Pos2::new(
-                rng.random_range(0. ..SPAWN_SIZE),
-                rng.random_range(0. ..SPAWN_SIZE),
-            ));
+            node.set_location(Pos2::new(SPAWN_SIZE * rng.f32(), SPAWN_SIZE * rng.f32()));
         }
 
         self.state.triggered = true;


### PR DESCRIPTION
fastrand is smaller and has fewer dependencies. It is not cryptographically secure, but I guess that doesn't matter here.

(Reimplementation of #233 which was too hard to rebase.)